### PR TITLE
Support disabling the external security groups

### DIFF
--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfiguration.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfiguration.cs
@@ -30,5 +30,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
         /// Gets or sets the when the HTML-based username/password form will be presented for domain users. Defaults to true. 
         /// </summary>
         public bool AllowFormsAuthenticationForDomainUsers { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to allow the use of security groups from AD.
+        /// </summary>
+        public bool AreSecurityGroupsDisabled { get; set; }
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfiguration.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfiguration.cs
@@ -12,6 +12,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
         public DirectoryServicesConfiguration(string name, string extensionAuthor) : base(name, extensionAuthor)
         {
             Id = DirectoryServicesConfigurationStore.SingletonId;
+            AllowFormsAuthenticationForDomainUsers = true;
+            AreSecurityGroupsEnabled = true;
         }
 
         public bool IsEnabled { get; set; }
@@ -34,6 +36,6 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
         /// <summary>
         /// Gets or sets whether to allow the use of security groups from AD.
         /// </summary>
-        public bool AreSecurityGroupsDisabled { get; set; }
+        public bool AreSecurityGroupsEnabled { get; set; }
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfigurationStore.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfigurationStore.cs
@@ -160,6 +160,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
             yield return new ConfigurationValue("Octopus.WebPortal.ActiveDirectoryContainer", GetActiveDirectoryContainer(), GetIsEnabled() && !string.IsNullOrWhiteSpace(GetActiveDirectoryContainer()), "Active Directory Container");
             yield return new ConfigurationValue("Octopus.WebPortal.AuthenticationScheme", GetAuthenticationScheme().ToString(), GetIsEnabled(), "Authentication Scheme");
             yield return new ConfigurationValue("Octopus.WebPortal.AllowFormsAuthenticationForDomainUsers", GetAllowFormsAuthenticationForDomainUsers().ToString(), GetIsEnabled(), "Allow forms authentication");
+            yield return new ConfigurationValue("Octopus.WebPortal.ExternalSecurityGroupsDisabled", GetAreSecurityGroupsDisabled().ToString(), GetIsEnabled(), "Security groups disabled");
         }
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfigurationStore.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfigurationStore.cs
@@ -106,21 +106,21 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
             configurationStore.Update(doc);
         }
 
-        public bool GetAreSecurityGroupsDisabled()
+        public bool GetAreSecurityGroupsEnabled()
         {
             var doc = configurationStore.Get<DirectoryServicesConfiguration>(SingletonId);
             if (doc != null)
-                return doc.AreSecurityGroupsDisabled;
+                return doc.AreSecurityGroupsEnabled;
 
             doc = MoveSettingsToDatabase();
 
-            return doc.AreSecurityGroupsDisabled;
+            return doc.AreSecurityGroupsEnabled;
         }
 
-        public void SetAreSecurityGroupsDisabled(bool areSecurityGroupsDisabled)
+        public void SetAreSecurityGroupsEnabled(bool areSecurityGroupsEnabled)
         {
             var doc = configurationStore.Get<DirectoryServicesConfiguration>(SingletonId) ?? MoveSettingsToDatabase();
-            doc.AreSecurityGroupsDisabled = areSecurityGroupsDisabled;
+            doc.AreSecurityGroupsEnabled = areSecurityGroupsEnabled;
             configurationStore.Update(doc);
         }
 
@@ -139,7 +139,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
                 ActiveDirectoryContainer = activeDirectoryContainer,
                 AuthenticationScheme = authenticationScheme,
                 AllowFormsAuthenticationForDomainUsers = allowFormsAuth,
-                AreSecurityGroupsDisabled = areSecurityGroupsDisabled
+                AreSecurityGroupsEnabled = !areSecurityGroupsDisabled
             };
 
             configurationStore.Create(doc);
@@ -160,7 +160,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
             yield return new ConfigurationValue("Octopus.WebPortal.ActiveDirectoryContainer", GetActiveDirectoryContainer(), GetIsEnabled() && !string.IsNullOrWhiteSpace(GetActiveDirectoryContainer()), "Active Directory Container");
             yield return new ConfigurationValue("Octopus.WebPortal.AuthenticationScheme", GetAuthenticationScheme().ToString(), GetIsEnabled(), "Authentication Scheme");
             yield return new ConfigurationValue("Octopus.WebPortal.AllowFormsAuthenticationForDomainUsers", GetAllowFormsAuthenticationForDomainUsers().ToString(), GetIsEnabled(), "Allow forms authentication");
-            yield return new ConfigurationValue("Octopus.WebPortal.ExternalSecurityGroupsDisabled", GetAreSecurityGroupsDisabled().ToString(), GetIsEnabled(), "Security groups disabled");
+            yield return new ConfigurationValue("Octopus.WebPortal.ActiveDirectorySecurityGroupsEnabled", GetAreSecurityGroupsEnabled().ToString(), GetIsEnabled(), "Security groups enabled");
         }
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfigureCommands.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfigureCommands.cs
@@ -44,11 +44,11 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
                 activeDirectoryConfiguration.SetAllowFormsAuthenticationForDomainUsers(allowFormsAuthenticationForDomainUsers);
                 log.Info("Allow forms authentication for domain users: " + allowFormsAuthenticationForDomainUsers);
             });
-            yield return new ConfigureCommandOption("activeDirectorySecurityGroupsDisabled=", "When Domain authentication is used, specifies whether to support security groups from AD.", v =>
+            yield return new ConfigureCommandOption("activeDirectorySecurityGroupsEnabled=", "When Domain authentication is used, specifies whether to support security groups from AD.", v =>
             {
-                var externalSecurityGroupsDisabled = bool.Parse(v);
-                activeDirectoryConfiguration.SetAreSecurityGroupsDisabled(externalSecurityGroupsDisabled);
-                log.Info("Active Directory security groups disabled: " + externalSecurityGroupsDisabled);
+                var externalSecurityGroupsEnabled = bool.Parse(v);
+                activeDirectoryConfiguration.SetAreSecurityGroupsEnabled(externalSecurityGroupsEnabled);
+                log.Info("Active Directory security groups enabled: " + externalSecurityGroupsEnabled);
             });
 
         }

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfigureCommands.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/DirectoryServicesConfigureCommands.cs
@@ -44,6 +44,12 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
                 activeDirectoryConfiguration.SetAllowFormsAuthenticationForDomainUsers(allowFormsAuthenticationForDomainUsers);
                 log.Info("Allow forms authentication for domain users: " + allowFormsAuthenticationForDomainUsers);
             });
+            yield return new ConfigureCommandOption("activeDirectorySecurityGroupsDisabled=", "When Domain authentication is used, specifies whether to support security groups from AD.", v =>
+            {
+                var externalSecurityGroupsDisabled = bool.Parse(v);
+                activeDirectoryConfiguration.SetAreSecurityGroupsDisabled(externalSecurityGroupsDisabled);
+                log.Info("Active Directory security groups disabled: " + externalSecurityGroupsDisabled);
+            });
 
         }
 

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/IDirectoryServicesConfigurationStore.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/IDirectoryServicesConfigurationStore.cs
@@ -13,5 +13,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
 
         bool GetAllowFormsAuthenticationForDomainUsers();
         void SetAllowFormsAuthenticationForDomainUsers(bool allowFormAuth);
+
+        bool GetAreSecurityGroupsDisabled();
+        void SetAreSecurityGroupsDisabled(bool allowFormAuth);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/IDirectoryServicesConfigurationStore.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Configuration/IDirectoryServicesConfigurationStore.cs
@@ -14,7 +14,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
         bool GetAllowFormsAuthenticationForDomainUsers();
         void SetAllowFormsAuthenticationForDomainUsers(bool allowFormAuth);
 
-        bool GetAreSecurityGroupsDisabled();
-        void SetAreSecurityGroupsDisabled(bool allowFormAuth);
+        bool GetAreSecurityGroupsEnabled();
+        void SetAreSecurityGroupsEnabled(bool areSecurityGroupsEnabled);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
@@ -29,7 +29,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
         public IList<ExternalSecurityGroup> FindGroups(string name)
         {
-            if (configurationStore.GetAreSecurityGroupsDisabled())
+            if (!configurationStore.GetAreSecurityGroupsEnabled())
                 return new List<ExternalSecurityGroup>();
 
             var results = new List<ExternalSecurityGroup>();
@@ -68,7 +68,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         {
             if (username == null) throw new ArgumentNullException("username");
 
-            if (configurationStore.GetAreSecurityGroupsDisabled())
+            if (!configurationStore.GetAreSecurityGroupsEnabled())
                 return new DirectoryServicesExternalSecurityGroupLocatorResult(new List<string>());
 
             log.Verbose($"Finding external security groups for '{username}'...");

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.DirectoryServices.AccountManagement;
 using System.Linq;
 using Octopus.Diagnostics;
+using Octopus.Server.Extensibility.Authentication.DirectoryServices.Configuration;
 using Octopus.Server.Extensibility.Authentication.HostServices;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
@@ -12,19 +13,25 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         readonly ILog log;
         readonly IDirectoryServicesContextProvider contextProvider;
         readonly IDirectoryServicesCredentialNormalizer credentialNormalizer;
+        readonly IDirectoryServicesConfigurationStore configurationStore;
 
         public DirectoryServicesExternalSecurityGroupLocator(
             ILog log,
             IDirectoryServicesContextProvider contextProvider,
-            IDirectoryServicesCredentialNormalizer credentialNormalizer)
+            IDirectoryServicesCredentialNormalizer credentialNormalizer,
+            IDirectoryServicesConfigurationStore configurationStore)
         {
             this.log = log;
             this.contextProvider = contextProvider;
             this.credentialNormalizer = credentialNormalizer;
+            this.configurationStore = configurationStore;
         }
 
         public IList<ExternalSecurityGroup> FindGroups(string name)
         {
+            if (configurationStore.GetAreSecurityGroupsDisabled())
+                return new List<ExternalSecurityGroup>();
+
             var results = new List<ExternalSecurityGroup>();
             string domain;
             string username;
@@ -60,6 +67,9 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         public DirectoryServicesExternalSecurityGroupLocatorResult GetGroupIdsForUser(string username)
         {
             if (username == null) throw new ArgumentNullException("username");
+
+            if (configurationStore.GetAreSecurityGroupsDisabled())
+                return new DirectoryServicesExternalSecurityGroupLocatorResult(new List<string>());
 
             log.Verbose($"Finding external security groups for '{username}'...");
 

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesGroupsChecker.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesGroupsChecker.cs
@@ -33,7 +33,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
         public HashSet<string> EnsureExternalSecurityGroupsAreUpToDate(IUser user, bool forceRefresh = false)
         {
-            if (!configurationStore.GetIsEnabled())
+            if (!configurationStore.GetIsEnabled() || configurationStore.GetAreSecurityGroupsDisabled())
                 return new HashSet<string>();
 
             // We will retrieve the user's external groups when they initially log in.  We can also refresh

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesGroupsChecker.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesGroupsChecker.cs
@@ -33,7 +33,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
         public HashSet<string> EnsureExternalSecurityGroupsAreUpToDate(IUser user, bool forceRefresh = false)
         {
-            if (!configurationStore.GetIsEnabled() || configurationStore.GetAreSecurityGroupsDisabled())
+            if (!configurationStore.GetIsEnabled() || !configurationStore.GetAreSecurityGroupsEnabled())
                 return new HashSet<string>();
 
             // We will retrieve the user's external groups when they initially log in.  We can also refresh

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServicesAuthenticationProvider.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServicesAuthenticationProvider.cs
@@ -44,7 +44,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices
 
         public AuthenticationProviderThatSupportsGroups GetGroupLookupElement()
         {
-            if (configurationStore.GetAreSecurityGroupsDisabled())
+            if (!configurationStore.GetAreSecurityGroupsEnabled())
                 return null;
             return new AuthenticationProviderThatSupportsGroups
             {

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServicesAuthenticationProvider.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServicesAuthenticationProvider.cs
@@ -44,6 +44,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices
 
         public AuthenticationProviderThatSupportsGroups GetGroupLookupElement()
         {
+            if (configurationStore.GetAreSecurityGroupsDisabled())
+                return null;
             return new AuthenticationProviderThatSupportsGroups
             {
                 Name = IdentityProviderName,


### PR DESCRIPTION
Some customers want to be able to disable the use of the external groups, i.e. not use AD groups