### PR TITLE
Fix cross domain support

### DIFF
--- a/source/DirectoryServices.Tests/ActiveDirectoryMembershipTests.cs
+++ b/source/DirectoryServices.Tests/ActiveDirectoryMembershipTests.cs
@@ -16,8 +16,8 @@ namespace DirectoryServices.Tests
         {
             string usernamePart, domainPart;
             var log = Substitute.For<ILog>();
-            var credentialNormalizer = new DirectoryServicesCredentialNormalizer(log);
-            credentialNormalizer.NormalizeCredentials(rawUsername, out usernamePart, out domainPart);
+            var credentialNormalizer = new DirectoryServicesObjectNameNormalizer(log);
+            credentialNormalizer.NormalizeName(rawUsername, out usernamePart, out domainPart);
             Assert.AreEqual(usedUsername, usernamePart);
             Assert.AreEqual(usedDomain, domainPart);
         }

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesCredentialValidator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesCredentialValidator.cs
@@ -67,6 +67,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
                 {
                     var searchedContext = domain ?? context.Name ?? context.ConnectedServer;
                     log.Info($"A principal identifiable by '{username}' was not found in '{searchedContext}'");
+                    if (username.Contains("@"))
+                    {
+                        return new UserCreateOrUpdateResult($"Username not found.  UPN format may not be supported for your domain configuration.");
+                    }
                     return new UserCreateOrUpdateResult($"Username not found");
                 }
 

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesCredentialValidator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesCredentialValidator.cs
@@ -25,20 +25,20 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         const int LOGON32_PROVIDER_DEFAULT = 0;
 
         readonly ILog log;
-        readonly IDirectoryServicesCredentialNormalizer credentialNormalizer;
+        readonly IDirectoryServicesObjectNameNormalizer objectNameNormalizer;
         readonly IDirectoryServicesContextProvider contextProvider;
         readonly IUserStore userStore;
         readonly IDirectoryServicesConfigurationStore configurationStore;
 
         public DirectoryServicesCredentialValidator(
             ILog log, 
-            IDirectoryServicesCredentialNormalizer credentialNormalizer,
+            IDirectoryServicesObjectNameNormalizer objectNameNormalizer,
             IDirectoryServicesContextProvider contextProvider,
             IUserStore userStore,
             IDirectoryServicesConfigurationStore configurationStore)
         {
             this.log = log;
-            this.credentialNormalizer = credentialNormalizer;
+            this.objectNameNormalizer = objectNameNormalizer;
             this.contextProvider = contextProvider;
             this.userStore = userStore;
             this.configurationStore = configurationStore;
@@ -57,7 +57,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             log.Verbose($"Validating credentials provided for '{username}'...");
 
             string domain;
-            credentialNormalizer.NormalizeCredentials(username, out username, out domain);
+            objectNameNormalizer.NormalizeName(username, out username, out domain);
 
             using (var context = contextProvider.GetContext(domain))
             {
@@ -102,7 +102,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         public UserCreateOrUpdateResult GetOrCreateUser(string username)
         {
             string domain;
-            credentialNormalizer.NormalizeCredentials(username, out username, out domain);
+            objectNameNormalizer.NormalizeName(username, out username, out domain);
 
             using (var context = contextProvider.GetContext(domain))
             {
@@ -119,7 +119,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
         UserCreateOrUpdateResult GetOrCreateUser(UserPrincipal principal, string fallbackUsername, string fallbackDomain)
         {
-            var name = credentialNormalizer.ValidatedUserPrincipalName(principal, fallbackUsername, fallbackDomain);
+            var name = objectNameNormalizer.ValidatedUserPrincipalName(principal, fallbackUsername, fallbackDomain);
 
             var externalId = principal.SamAccountName;
             if (!string.IsNullOrWhiteSpace(fallbackDomain))

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesCredentialValidator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesCredentialValidator.cs
@@ -117,11 +117,17 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         {
             var name = credentialNormalizer.ValidatedUserPrincipalName(principal, fallbackUsername, fallbackDomain);
 
+            var externalId = principal.SamAccountName;
+            if (!string.IsNullOrWhiteSpace(fallbackDomain))
+            {
+                externalId = fallbackDomain + @"\" + externalId;
+            }
+
             return userStore.CreateOrUpdate(
                 name,
                 string.IsNullOrWhiteSpace(principal.DisplayName) ? principal.Name : principal.DisplayName,
                 principal.EmailAddress,
-                principal.SamAccountName,
+                externalId,
                 null,
                 true,
                 null,

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
@@ -12,18 +12,18 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
     {
         readonly ILog log;
         readonly IDirectoryServicesContextProvider contextProvider;
-        readonly IDirectoryServicesCredentialNormalizer credentialNormalizer;
+        readonly IDirectoryServicesObjectNameNormalizer objectNameNormalizer;
         readonly IDirectoryServicesConfigurationStore configurationStore;
 
         public DirectoryServicesExternalSecurityGroupLocator(
             ILog log,
             IDirectoryServicesContextProvider contextProvider,
-            IDirectoryServicesCredentialNormalizer credentialNormalizer,
+            IDirectoryServicesObjectNameNormalizer objectNameNormalizer,
             IDirectoryServicesConfigurationStore configurationStore)
         {
             this.log = log;
             this.contextProvider = contextProvider;
-            this.credentialNormalizer = credentialNormalizer;
+            this.objectNameNormalizer = objectNameNormalizer;
             this.configurationStore = configurationStore;
         }
 
@@ -35,7 +35,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             var results = new List<ExternalSecurityGroup>();
             string domain;
             string partialGroupName;
-            credentialNormalizer.NormalizeCredentials(name, out partialGroupName, out domain);
+            objectNameNormalizer.NormalizeName(name, out partialGroupName, out domain);
             using (var context = contextProvider.GetContext(domain))
             {
                 var searcher = new PrincipalSearcher();
@@ -66,7 +66,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
         public DirectoryServicesExternalSecurityGroupLocatorResult GetGroupIdsForUser(string externalId)
         {
-            if (externalId == null) throw new ArgumentNullException("externalId");
+            if (externalId == null) throw new ArgumentNullException(nameof(externalId));
 
             if (!configurationStore.GetAreSecurityGroupsEnabled())
                 return new DirectoryServicesExternalSecurityGroupLocatorResult(new List<string>());
@@ -74,7 +74,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             log.Verbose($"Finding external security groups for '{externalId}'...");
 
             string domain;
-            credentialNormalizer.NormalizeCredentials(externalId, out externalId, out domain);
+            objectNameNormalizer.NormalizeName(externalId, out externalId, out domain);
 
             var groups = new List<string>();
 

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
@@ -64,27 +64,27 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             return results.OrderBy(o => o.DisplayName).ToList();
         }
 
-        public DirectoryServicesExternalSecurityGroupLocatorResult GetGroupIdsForUser(string username)
+        public DirectoryServicesExternalSecurityGroupLocatorResult GetGroupIdsForUser(string externalId)
         {
-            if (username == null) throw new ArgumentNullException("username");
+            if (externalId == null) throw new ArgumentNullException("externalId");
 
             if (!configurationStore.GetAreSecurityGroupsEnabled())
                 return new DirectoryServicesExternalSecurityGroupLocatorResult(new List<string>());
 
-            log.Verbose($"Finding external security groups for '{username}'...");
+            log.Verbose($"Finding external security groups for '{externalId}'...");
 
             string domain;
-            credentialNormalizer.NormalizeCredentials(username, out username, out domain);
+            credentialNormalizer.NormalizeCredentials(externalId, out externalId, out domain);
 
             var groups = new List<string>();
 
             using (var context = contextProvider.GetContext(domain))
             {
-                var principal = UserPrincipal.FindByIdentity(context, username);
+                var principal = UserPrincipal.FindByIdentity(context, externalId);
                 if (principal == null)
                 {
                     var searchedContext = domain ?? context.Name ?? context.ConnectedServer;
-                    log.Trace($"While loading security groups, a principal identifiable by '{username}' was not found in '{searchedContext}'");
+                    log.Trace($"While loading security groups, a principal identifiable by '{externalId}' was not found in '{searchedContext}'");
                     return new DirectoryServicesExternalSecurityGroupLocatorResult();
                 }
 

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
@@ -34,12 +34,12 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
             var results = new List<ExternalSecurityGroup>();
             string domain;
-            string username;
-            credentialNormalizer.NormalizeCredentials(name, out username, out domain);
+            string partialGroupName;
+            credentialNormalizer.NormalizeCredentials(name, out partialGroupName, out domain);
             using (var context = contextProvider.GetContext(domain))
             {
                 var searcher = new PrincipalSearcher();
-                searcher.QueryFilter = new GroupPrincipal(context) { Name = name + "*" };
+                searcher.QueryFilter = new GroupPrincipal(context) { Name = partialGroupName + "*" };
 
                 var iterGroup = searcher.FindAll().GetEnumerator();
                 using (iterGroup)

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesGroupsChecker.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesGroupsChecker.cs
@@ -44,7 +44,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             {
                 try
                 {
-                    var result = groupLocator.GetGroupIdsForUser(user.Username);
+                    var result = groupLocator.GetGroupIdsForUser(user.ExternalId);
                     if (!result.WasAbleToRetrieveGroups)
                         return new HashSet<string>();
 

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesObjectNameNormalizer.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/DirectoryServicesObjectNameNormalizer.cs
@@ -4,26 +4,26 @@ using Octopus.Diagnostics;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
 {
-    public class DirectoryServicesCredentialNormalizer : IDirectoryServicesCredentialNormalizer
+    public class DirectoryServicesObjectNameNormalizer : IDirectoryServicesObjectNameNormalizer
     {
         readonly ILog log;
         const string NTAccountUsernamePrefix = "nt:";
 
-        public DirectoryServicesCredentialNormalizer(ILog log)
+        public DirectoryServicesObjectNameNormalizer(ILog log)
         {
             this.log = log;
         }
 
-        public void NormalizeCredentials(string username, out string usernamePart, out string domainPart)
+        public void NormalizeName(string name, out string namePart, out string domainPart)
         {
-            if (username == null) throw new ArgumentNullException(nameof(username));
+            if (name == null) throw new ArgumentNullException(nameof(name));
 
-            if (username.StartsWith(NTAccountUsernamePrefix))
-                username = username.Remove(0, NTAccountUsernamePrefix.Length);
+            if (name.StartsWith(NTAccountUsernamePrefix))
+                name = name.Remove(0, NTAccountUsernamePrefix.Length);
 
-            if (!TryParseDownLevelLogonName(username, out usernamePart, out domainPart))
+            if (!TryParseDownLevelLogonName(name, out namePart, out domainPart))
             {
-                usernamePart = username;
+                namePart = name;
                 domainPart = null;
             }
         }
@@ -37,14 +37,14 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
                 if (string.IsNullOrWhiteSpace(fallbackDomain))
                     throw new InvalidOperationException("No fallback domain was provided");
                 if (string.IsNullOrWhiteSpace(fallbackUsername))
-                    throw new InvalidOperationException("No fallback username was provided");
+                    throw new InvalidOperationException("No fallback name was provided");
                 name = NTAccountUsernamePrefix + fallbackDomain.Trim() + "\\" + fallbackUsername.Trim();
             }
             return name;
         }
 
-        // If the return value is true, dlln was a valid down-level logon name, and username/domain
-        // contain precisely the component username and domain name values. Note, we don't split
+        // If the return value is true, dlln was a valid down-level logon name, and name/domain
+        // contain precisely the component name and domain name values. Note, we don't split
         // UPNs this way because the suffix part of a UPN is not necessarily a domain, and in
         // the default LogonUser case should be passed whole to the function with a null domain.
         static bool TryParseDownLevelLogonName(string dlln, out string username, out string domain)

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/IDirectoryServicesExternalSecurityGroupLocator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/IDirectoryServicesExternalSecurityGroupLocator.cs
@@ -7,6 +7,6 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
     {
         IList<ExternalSecurityGroup> FindGroups(string name);
 
-        DirectoryServicesExternalSecurityGroupLocatorResult GetGroupIdsForUser(string username);
+        DirectoryServicesExternalSecurityGroupLocatorResult GetGroupIdsForUser(string externalId);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/IDirectoryServicesObjectNameNormalizer.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServices/IDirectoryServicesObjectNameNormalizer.cs
@@ -2,9 +2,9 @@ using System.DirectoryServices.AccountManagement;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
 {
-    public interface IDirectoryServicesCredentialNormalizer
+    public interface IDirectoryServicesObjectNameNormalizer
     {
-        void NormalizeCredentials(string username, out string usernamePart, out string domainPart);
+        void NormalizeName(string name, out string namePart, out string domainPart);
 
         string ValidatedUserPrincipalName(UserPrincipal principal, string fallbackUsername, string fallbackDomain);
     }

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServicesExtension.cs
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/DirectoryServicesExtension.cs
@@ -30,7 +30,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices
             builder.RegisterType<DirectoryServicesUserCreationFromPrincipal>().As<ISupportsAutoUserCreationFromPrincipal>().InstancePerDependency();
 
             builder.RegisterType<DirectoryServicesContextProvider>().As<IDirectoryServicesContextProvider>().InstancePerDependency();
-            builder.RegisterType<DirectoryServicesCredentialNormalizer>().As<IDirectoryServicesCredentialNormalizer>().InstancePerDependency();
+            builder.RegisterType<DirectoryServicesObjectNameNormalizer>().As<IDirectoryServicesObjectNameNormalizer>().InstancePerDependency();
             builder.RegisterType<DirectoryServicesExternalSecurityGroupLocator>().As<IDirectoryServicesExternalSecurityGroupLocator>().InstancePerDependency();
 
             builder.RegisterType<DirectoryServicesCredentialValidator>().As<IDirectoryServicesCredentialValidator>().InstancePerDependency();

--- a/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Octopus.Server.Extensibility.Authentication.DirectoryServices.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication.DirectoryServices/Octopus.Server.Extensibility.Authentication.DirectoryServices.csproj
@@ -109,7 +109,7 @@
     <Compile Include="DirectoryServicesAuthenticationProvider.cs" />
     <Compile Include="DirectoryServices\DirectoryServicesConstants.cs" />
     <Compile Include="DirectoryServices\DirectoryServicesContextProvider.cs" />
-    <Compile Include="DirectoryServices\DirectoryServicesCredentialNormalizer.cs" />
+    <Compile Include="DirectoryServices\DirectoryServicesObjectNameNormalizer.cs" />
     <Compile Include="DirectoryServices\DirectoryServicesCredentialValidator.cs" />
     <Compile Include="DirectoryServices\DirectoryServicesExternalSecurityGroupLocator.cs" />
     <Compile Include="DirectoryServices\DirectoryServicesExternalSecurityGroupLocatorResult.cs" />
@@ -127,7 +127,7 @@
     <Compile Include="Configuration\DirectoryServicesConfigureCommands.cs" />
     <Compile Include="Configuration\IDirectoryServicesConfigurationStore.cs" />
     <Compile Include="DirectoryServices\IDirectoryServicesContextProvider.cs" />
-    <Compile Include="DirectoryServices\IDirectoryServicesCredentialNormalizer.cs" />
+    <Compile Include="DirectoryServices\IDirectoryServicesObjectNameNormalizer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Web\DirectoryServicesCSSContributor.cs" />
     <Compile Include="Web\DirectoryServicesStaticContentFolders.cs" />


### PR DESCRIPTION
Fixes several issues with cross domain support.

- ExternalIds being only SamAccountName meant that subsequent searches for groups would fail, because the domain couldn't be provided as context.  ExternalId is now stored as domain/username for accounts not in the same domain as the server (can be stored either as domain/username or just username for accounts in the same domain)

- Fixed bug with group search where the "normalised" object name wasn't being used correctly, which was preventing cross domain group searches

- New error message if UPN is used and user can't be found, as it could because you're not in the same domain as the server.

Have tested user login, team group editing and security group loading upon login on a local VM environment with 2 domains.  Tested with both 2-way and 1-way domain Trust configured.

Relates to OctopusDeploy/Issues#2335