### PR TITLE
AllowAutoUserCreation should not be nullable, we'll add a migration t…

### DIFF
--- a/source/Node/Configuration/DirectoryServicesConfiguration.cs
+++ b/source/Node/Configuration/DirectoryServicesConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.Net;
-using Octopus.Data.Resources;
+﻿using System.Net;
 using Octopus.Node.Extensibility.Extensions.Infrastructure.Configuration;
 
 namespace Octopus.Node.Extensibility.Authentication.DirectoryServices.Configuration
@@ -12,6 +10,7 @@ namespace Octopus.Node.Extensibility.Authentication.DirectoryServices.Configurat
             Id = DirectoryServicesConfigurationStore.SingletonId;
             AllowFormsAuthenticationForDomainUsers = true;
             AreSecurityGroupsEnabled = true;
+            AllowAutoUserCreation = true;
         }
 
         /// <summary>
@@ -33,9 +32,10 @@ namespace Octopus.Node.Extensibility.Authentication.DirectoryServices.Configurat
         /// Gets or sets whether to allow the use of security groups from AD.
         /// </summary>
         public bool AreSecurityGroupsEnabled { get; set; }
+        
         /// <summary>
         /// Gets or sets whether user records will be automatically created when someone passes authentication but is unknown.
         /// </summary>
-        public bool? AllowAutoUserCreation { get; set; }
+        public bool AllowAutoUserCreation { get; set; }
     }
 }

--- a/source/Node/Configuration/DirectoryServicesConfigurationStore.cs
+++ b/source/Node/Configuration/DirectoryServicesConfigurationStore.cs
@@ -61,7 +61,7 @@ namespace Octopus.Node.Extensibility.Authentication.DirectoryServices.Configurat
         
         public bool GetAllowAutoUserCreation()
         {
-            return GetProperty(doc => doc.AllowAutoUserCreation.GetValueOrDefault(true));
+            return GetProperty(doc => doc.AllowAutoUserCreation);
         }
 
         public void SetAllowAutoUserCreation(bool allowAutoUserCreation)


### PR DESCRIPTION
…o make existing records without a value explicitly set to true

Relates to OctopusDeploy/Issues/issues/4770