### PR TITLE
Support typed config values

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -21,7 +21,7 @@ var publishDir = "./publish";
 var localPackagesDir = "../LocalPackages";
 var artifactsDir = "./artifacts";
 var assetDir = "./BuildAssets";
-var bin451 = "/bin/Release/net451/";
+var bin452 = "/bin/Release/net452/";
 var std20 = "/bin/Release/netstandard2.0/";
 
 var gitVersionInfo = GitVersion(new GitVersionSettings {
@@ -117,10 +117,10 @@ Task("__Pack")
         CreateDirectory(odNugetPackDir);
         CopyFileToDirectory(Path.Combine(assetDir, nuspecFile), odNugetPackDir);
 
-		CopyFileToDirectory(solutionDir + "Server" + bin451 + "Octopus.Server.Extensibility.Authentication.DirectoryServices.dll", odNugetPackDir);
+		CopyFileToDirectory(solutionDir + "Server" + bin452 + "Octopus.Server.Extensibility.Authentication.DirectoryServices.dll", odNugetPackDir);
         // files = new [] {
-            // solutionDir + "Server" + bin451 + "Octopus.Node.Extensibility.Authentication.DirectoryServices.dll",
-            // solutionDir + "Server" + bin451 + "Octopus.Server.Extensibility.Authentication.DirectoryServices.dll"
+            // solutionDir + "Server" + bin452 + "Octopus.Node.Extensibility.Authentication.DirectoryServices.dll",
+            // solutionDir + "Server" + bin452 + "Octopus.Server.Extensibility.Authentication.DirectoryServices.dll"
         // };
         // Zip("./", Path.Combine(odNugetPackDir, "DirectoryServices.zip"), files);
         

--- a/source/Client/Client.csproj
+++ b/source/Client/Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <RootNamespace>Octopus.Client.Extensibility.Authentication.DirectoryServices</RootNamespace>
     <AssemblyName>Octopus.Client.Extensibility.Authentication.DirectoryServices</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Client" Version="4.42.4" />
+    <PackageReference Include="Octopus.Client" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Configuration/DirectoryServicesConfigurationSettings.cs
+++ b/source/Server/Configuration/DirectoryServicesConfigurationSettings.cs
@@ -19,16 +19,16 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
 
         public override string Description => "Active Directory authentication settings";
 
-        public override IEnumerable<ConfigurationValue> GetConfigurationValues()
+        public override IEnumerable<IConfigurationValue> GetConfigurationValues()
         {
             var isEnabled = ConfigurationDocumentStore.GetIsEnabled();
 
-            yield return new ConfigurationValue("Octopus.WebPortal.ActiveDirectoryIsEnabled", isEnabled.ToString(), isEnabled, "Is Enabled");
-            yield return new ConfigurationValue("Octopus.WebPortal.ActiveDirectoryContainer", ConfigurationDocumentStore.GetActiveDirectoryContainer(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetActiveDirectoryContainer()), "Active Directory Container");
-            yield return new ConfigurationValue("Octopus.WebPortal.AuthenticationScheme", ConfigurationDocumentStore.GetAuthenticationScheme().ToString(), isEnabled, "Authentication Scheme");
-            yield return new ConfigurationValue("Octopus.WebPortal.AllowFormsAuthenticationForDomainUsers", ConfigurationDocumentStore.GetAllowFormsAuthenticationForDomainUsers().ToString(), isEnabled, "Allow forms authentication");
-            yield return new ConfigurationValue("Octopus.WebPortal.ExternalSecurityGroupsDisabled", ConfigurationDocumentStore.GetAreSecurityGroupsEnabled().ToString(), isEnabled, "Security groups enabled");
-            yield return new ConfigurationValue("Octopus.WebPortal.ActiveDirectoryAllowAutoUserCreation", ConfigurationDocumentStore.GetAllowAutoUserCreation().ToString(), isEnabled, "Allow auto user creation");
+            yield return new ConfigurationValue<bool>("Octopus.WebPortal.ActiveDirectoryIsEnabled", isEnabled, isEnabled, "Is Enabled");
+            yield return new ConfigurationValue<string>("Octopus.WebPortal.ActiveDirectoryContainer", ConfigurationDocumentStore.GetActiveDirectoryContainer(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetActiveDirectoryContainer()), "Active Directory Container");
+            yield return new ConfigurationValue<string>("Octopus.WebPortal.AuthenticationScheme", ConfigurationDocumentStore.GetAuthenticationScheme().ToString(), isEnabled, "Authentication Scheme");
+            yield return new ConfigurationValue<bool>("Octopus.WebPortal.AllowFormsAuthenticationForDomainUsers", ConfigurationDocumentStore.GetAllowFormsAuthenticationForDomainUsers(), isEnabled, "Allow forms authentication");
+            yield return new ConfigurationValue<bool>("Octopus.WebPortal.ExternalSecurityGroupsDisabled", ConfigurationDocumentStore.GetAreSecurityGroupsEnabled(), isEnabled, "Security groups enabled");
+            yield return new ConfigurationValue<bool>("Octopus.WebPortal.ActiveDirectoryAllowAutoUserCreation", ConfigurationDocumentStore.GetAllowAutoUserCreation(), isEnabled, "Allow auto user creation");
         }
 
         public override void BuildMappings(IResourceMappingsBuilder builder)

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -23,8 +23,8 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.2.2" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.0.3" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.0.2" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.0.4-enh-typedconfig0001" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.0.3-enh-typedconfig0001" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.DirectoryServices</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.DirectoryServices</AssemblyName>
     <FileAlignment>512</FileAlignment>
@@ -22,9 +22,9 @@
     <PackageReference Include="Autofac" Version="4.6.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.2.2" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.0.4-enh-typedconfig0001" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.0.3-enh-typedconfig0001" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.1.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.1.2" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />


### PR DESCRIPTION
Relates to OctopusDeploy/ServerExtensibility#12 and https://github.com/OctopusDeploy/AuthenticationExtensibility/pull/10

Allow config values to use their base type (int/bool/string), rather than casting everything to a string