### PR TITLE
Email is no longer unique

### DIFF
--- a/source/DirectoryServices.Tests/CredentialValidatorTests.cs
+++ b/source/DirectoryServices.Tests/CredentialValidatorTests.cs
@@ -1,0 +1,262 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Nevermore.Contracts;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Data.Model.User;
+using Octopus.Data.Storage.User;
+using Octopus.Diagnostics;
+using Octopus.Server.Extensibility.Authentication.DirectoryServices.Configuration;
+using Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices;
+using Octopus.Server.Extensibility.Authentication.DirectoryServices.Identities;
+using Octopus.Server.Extensibility.Authentication.HostServices;
+using Shouldly;
+
+namespace DirectoryServices.Tests
+{
+    [TestFixture]
+    public class CredentialValidatorTests
+    {
+        IDirectoryServicesConfigurationStore directoryServicesConfigurationStore;
+        IUpdateableUserStore updateableUserStore;
+        IDirectoryServicesService directoryServicesService;
+        DirectoryServicesCredentialValidator validator;
+        IdentityCreator identityCreator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            directoryServicesConfigurationStore = Substitute.For<IDirectoryServicesConfigurationStore>();
+            directoryServicesConfigurationStore.GetIsEnabled().Returns(true);
+            directoryServicesConfigurationStore.GetAllowFormsAuthenticationForDomainUsers().Returns(true);
+            directoryServicesConfigurationStore.GetAllowAutoUserCreation().Returns(true);
+
+            updateableUserStore = Substitute.For<IUpdateableUserStore>();
+
+            directoryServicesService = Substitute.For<IDirectoryServicesService>();
+            
+            var log = Substitute.For<ILog>();
+
+            identityCreator = new IdentityCreator();
+
+            validator = new DirectoryServicesCredentialValidator(log,
+                new DirectoryServicesObjectNameNormalizer(log),
+                updateableUserStore,
+                directoryServicesConfigurationStore,
+                identityCreator,
+                directoryServicesService);
+        }
+        [Test]
+        public void InvalidUser()
+        {
+            directoryServicesService.ValidateCredentials("invalidUser", "testPassword", CancellationToken.None).Returns(new UserValidationResult("User not found"));
+
+            var result = validator.ValidateCredentials("invalidUser", "testPassword", CancellationToken.None);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason.ShouldBe("User not found");
+            updateableUserStore.DidNotReceive().Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
+        }
+
+        [Test]
+        public void ExistingUserWithMatchingIdentity()
+        {
+            directoryServicesService.ValidateCredentials("existingUser", "testPassword", CancellationToken.None)
+                .Returns(new UserValidationResult("existingUser@test.com", "existingUser", "TestDomain", string.Empty, String.Empty));
+
+            var user = new User("Users-100", "existingUser", identityCreator.Create(string.Empty, "existingUser@test.com", "TestDomain\\existingUser", string.Empty));
+
+            updateableUserStore.GetByIdentity(Arg.Any<Identity>()).Returns(new [] { user });
+
+            var result = validator.ValidateCredentials("existingUser", "testPassword", CancellationToken.None);
+
+            result.Succeeded.ShouldBeTrue();
+            updateableUserStore.DidNotReceive().UpdateIdentity(Arg.Any<string>(), Arg.Any<Identity>(), CancellationToken.None);
+        }
+
+        [Test]
+        public void NewUserWithNoMatchingIdentity()
+        {
+            directoryServicesService.ValidateCredentials("newUser", "testPassword", CancellationToken.None)
+                .Returns(new UserValidationResult("newUser@test.com", "newUser", "TestDomain", string.Empty, String.Empty));
+
+            updateableUserStore.GetByIdentity(Arg.Any<Identity>()).Returns(new IUser[0]);
+
+            var user = new User("Users-100", "newUser", identityCreator.Create(string.Empty, "newUser@test.com", "TestDomain\\newUser", string.Empty));
+            updateableUserStore.Create("newUser@test.com", Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None, Arg.Any<ProviderUserGroups>(), Arg.Any<IEnumerable<Identity>>())
+                .Returns(new UserCreateResult(user));
+
+            var result = validator.ValidateCredentials("newUser", "testPassword", CancellationToken.None);
+
+            result.Succeeded.ShouldBeTrue();
+            updateableUserStore.Received(1).Create("newUser@test.com", Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None, Arg.Any<ProviderUserGroups>(), Arg.Any<IEnumerable<Identity>>());
+        }
+
+        [Test]
+        public void NewUserWithPartialMatchOnExistingEmail()
+        {
+            directoryServicesService.ValidateCredentials("newUser", "testPassword", CancellationToken.None)
+                .Returns(new UserValidationResult("newUser@test.com", "newUser", "TestDomain", string.Empty, "tester@test.com"));
+
+            var user = new User("Users-100", "existingUser", identityCreator.Create("tester@test.com", "existingUser@test.com", "TestDomain\\existingUser", ""));
+
+            updateableUserStore.GetByIdentity(Arg.Any<Identity>()).Returns(new[] { user });
+
+            updateableUserStore.Create("newUser@test.com", Arg.Any<string>(), "tester@test.com", CancellationToken.None, Arg.Any<ProviderUserGroups>(), Arg.Any<IEnumerable<Identity>>())
+                .Returns(new UserCreateResult(user));
+
+            directoryServicesService.FindByIdentity("TestDomain\\existingUser").Returns(new UserValidationResult("existingUser@test.com", "existingUser", "TestDomain", string.Empty, "tester@test.com"));
+
+            var result = validator.ValidateCredentials("newUser", "testPassword", CancellationToken.None);
+
+            result.Succeeded.ShouldBeTrue();
+            updateableUserStore.Received(1).Create("newUser@test.com", Arg.Any<string>(), "tester@test.com", CancellationToken.None, Arg.Any<ProviderUserGroups>(), Arg.Any<IEnumerable<Identity>>());
+        }
+
+        [Test]
+        public void ExistingUsersWithPartialMatchOnEmailButMatchingIdentity()
+        {
+            directoryServicesService.ValidateCredentials("existingUser2", "testPassword", CancellationToken.None)
+                .Returns(new UserValidationResult("existingUser2@test.com", "existingUser2", "TestDomain", string.Empty, "tester@test.com"));
+
+            var user1 = new User("Users-100", "existingUser1", identityCreator.Create("tester@test.com", "existingUser1@test.com", "TestDomain\\existingUser1", ""));
+            var user2 = new User("Users-101", "existingUser2", identityCreator.Create("tester@test.com", "existingUser2@test.com", "TestDomain\\existingUser2", ""));
+
+            updateableUserStore.GetByIdentity(Arg.Any<Identity>()).Returns(new[] { user1, user2 });
+
+            var result = validator.ValidateCredentials("existingUser2", "testPassword", CancellationToken.None);
+
+            result.Succeeded.ShouldBeTrue();
+            updateableUserStore.DidNotReceive().Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
+        }
+
+        [Test]
+        public void NewUserWhenCreateInNotAllowed()
+        {
+            directoryServicesConfigurationStore.GetAllowAutoUserCreation().Returns(false);
+
+            directoryServicesService.ValidateCredentials("newUser", "testPassword", CancellationToken.None)
+                .Returns(new UserValidationResult("newUser@test.com", "newUser", "TestDomain", string.Empty, String.Empty));
+
+            updateableUserStore.GetByIdentity(Arg.Any<Identity>()).Returns(new IUser[0]);
+
+            var result = validator.ValidateCredentials("newUser", "testPassword", CancellationToken.None);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason.ShouldBe("User could not be located and auto user creation is not enabled.");
+        }
+
+        [Test]
+        public void NewUserFromAnotherDomain()
+        {
+            directoryServicesService.ValidateCredentials("Domain2\\newUser", "testPassword", CancellationToken.None)
+                .Returns(new UserValidationResult("newUser@domain2.com", "newUser", "Domain2", string.Empty, String.Empty));
+
+            updateableUserStore.GetByIdentity(Arg.Any<Identity>()).Returns(new IUser[0]);
+
+            var user = new User("Users-100", "newUser", identityCreator.Create(string.Empty, "newUser@domain2.com", "Domain2\\newUser", string.Empty));
+            updateableUserStore.Create("newUser@domain2.com", Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None, Arg.Any<ProviderUserGroups>(), Arg.Any<IEnumerable<Identity>>())
+                .Returns(new UserCreateResult(user));
+
+            var result = validator.ValidateCredentials("Domain2\\newUser", "testPassword", CancellationToken.None);
+
+            result.Succeeded.ShouldBeTrue();
+            updateableUserStore.Received(1).Create("newUser@domain2.com", Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None, Arg.Any<ProviderUserGroups>(), Arg.Any<IEnumerable<Identity>>());
+        }
+
+        [Test]
+        public void ExistingUserWhoHadTheirUpnChanged()
+        {
+            directoryServicesService.ValidateCredentials("existingUser", "testPassword", CancellationToken.None)
+                .Returns(new UserValidationResult("existingUser@new.test.com", "existingUser", "TestDomain", string.Empty, String.Empty));
+
+            var user = new User("Users-100", "existingUser", identityCreator.Create(string.Empty, "existingUser@test.com", "TestDomain\\existingUser", string.Empty));
+
+            updateableUserStore.GetByIdentity(Arg.Any<Identity>()).Returns(new[] { user });
+
+            var result = validator.ValidateCredentials("existingUser", "testPassword", CancellationToken.None);
+
+            result.Succeeded.ShouldBeTrue();
+            updateableUserStore.Received(1).UpdateIdentity("Users-100", Arg.Any<Identity>(), CancellationToken.None);
+            updateableUserStore.DidNotReceive().Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
+        }
+
+        [Test]
+        public void ExistingUserWhoHadTheirSamAccountNameChanged()
+        {
+            directoryServicesService.ValidateCredentials("existingUserWithNewSam", "testPassword", CancellationToken.None)
+                .Returns(new UserValidationResult("existingUser@test.com", "existingUserWithNewSam", "TestDomain", string.Empty, String.Empty));
+
+            var user = new User("Users-100", "existingUser", identityCreator.Create(string.Empty, "existingUser@test.com", "TestDomain\\existingUser", string.Empty));
+
+            updateableUserStore.GetByIdentity(Arg.Any<Identity>()).Returns(new[] { user });
+
+            var result = validator.ValidateCredentials("existingUserWithNewSam", "testPassword", CancellationToken.None);
+
+            result.Succeeded.ShouldBeTrue();
+            updateableUserStore.Received(1).UpdateIdentity("Users-100", Arg.Any<Identity>(), CancellationToken.None);
+            updateableUserStore.DidNotReceive().Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
+        }
+
+        [Test]
+        public void ExistingUserWhoHadTheirUpnAndSamAccountNameChanged()
+        {
+            directoryServicesService.ValidateCredentials("existingUserWithNewSam", "testPassword", CancellationToken.None)
+                .Returns(new UserValidationResult("existingUser@new.test.com", "existingUserWithNewSam", "TestDomain", string.Empty, String.Empty));
+
+            var user = new User("Users-100", "existingUser", identityCreator.Create(string.Empty, "existingUser@test.com", "TestDomain\\existingUser", string.Empty));
+
+            updateableUserStore.GetByIdentity(Arg.Any<Identity>()).Returns(new[] { user });
+
+            directoryServicesService.FindByIdentity("TestDomain\\existingUser").Returns(new UserValidationResult("User not found"));
+
+            var result = validator.ValidateCredentials("existingUserWithNewSam", "testPassword", CancellationToken.None);
+
+            result.Succeeded.ShouldBeTrue();
+            updateableUserStore.Received(1).UpdateIdentity("Users-100", Arg.Any<Identity>(), CancellationToken.None);
+            updateableUserStore.DidNotReceive().Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
+        }
+
+        private class User : IUser
+        {
+            public User(string id, string username, Identity identity)
+            {
+                Id = id;
+                Username = username;
+                Identities = new HashSet<Identity>(new [] {identity});
+            }
+
+            public string Id { get; }
+            public string Username { get; }
+            public Guid IdentificationToken { get; }
+            public string DisplayName { get; set; }
+            public string EmailAddress { get; set; }
+            public bool IsService { get; set; }
+            public bool IsActive { get; set; }
+            public ReferenceCollection ExternalIdentifiers { get; }
+            public HashSet<Identity> Identities { get; }
+
+            public void SetPassword(string plainTextPassword)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool ValidatePassword(string plainTextPassword)
+            {
+                throw new NotImplementedException();
+            }
+
+            public SecurityGroups GetSecurityGroups(string identityProviderName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerable<string> GetSecurityGroups()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/source/DirectoryServices.Tests/DirectoryServices.Tests.csproj
+++ b/source/DirectoryServices.Tests/DirectoryServices.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Shouldly" Version="2.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Server\Server.csproj" />

--- a/source/Server/DirectoryServices/DirectoryServicesObjectNameNormalizer.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesObjectNameNormalizer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.DirectoryServices.AccountManagement;
 using Octopus.Diagnostics;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
@@ -28,12 +27,12 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             }
         }
 
-        public string ValidatedUserPrincipalName(UserPrincipal principal, string fallbackUsername, string fallbackDomain)
+        public string ValidatedUserPrincipalName(string userPrincipalName, string fallbackUsername, string fallbackDomain)
         {
-            var name = principal.UserPrincipalName;
+            var name = userPrincipalName;
             if (name == null)
             {
-                log.Warn($"The user name (UPN) could not be determined for principal {principal} - falling back to NT-style '{fallbackDomain}\\{fallbackUsername}'");
+                log.Warn($"The user name (UPN) could not be determined for principal - falling back to NT-style '{fallbackDomain}\\{fallbackUsername}'");
                 if (string.IsNullOrWhiteSpace(fallbackDomain))
                     throw new InvalidOperationException("No fallback domain was provided");
                 if (string.IsNullOrWhiteSpace(fallbackUsername))

--- a/source/Server/DirectoryServices/DirectoryServicesService.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesService.cs
@@ -1,0 +1,116 @@
+using System;
+using System.ComponentModel;
+using System.DirectoryServices.AccountManagement;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Octopus.Diagnostics;
+
+namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
+{
+    public class DirectoryServicesService : IDirectoryServicesService
+    {
+        readonly ILog log;
+        readonly IDirectoryServicesObjectNameNormalizer objectNameNormalizer;
+        readonly IDirectoryServicesContextProvider contextProvider;
+
+        /// <summary>
+        /// This logon type is intended for high performance servers to authenticate plaintext passwords.
+        /// The LogonUser function does not cache credentials for this logon type.
+        /// </summary>
+        const int LOGON32_LOGON_NETWORK = 3;
+
+        /// <summary>
+        /// Use the standard logon provider for the system.
+        /// The default security provider is negotiate, unless you pass NULL for the domain name and the user name
+        /// is not in UPN format. In this case, the default provider is NTLM.
+        /// NOTE: Windows 2000/NT:   The default security provider is NTLM.
+        /// </summary>
+        const int LOGON32_PROVIDER_DEFAULT = 0;
+
+        public DirectoryServicesService(ILog log, 
+            IDirectoryServicesObjectNameNormalizer objectNameNormalizer,
+            IDirectoryServicesContextProvider contextProvider)
+        {
+            this.log = log;
+            this.objectNameNormalizer = objectNameNormalizer;
+            this.contextProvider = contextProvider;
+        }
+
+        public UserValidationResult ValidateCredentials(string username, string password, CancellationToken cancellationToken)
+        {
+            log.Verbose($"Validating credentials provided for '{username}'...");
+
+            objectNameNormalizer.NormalizeName(username, out username, out var domain);
+
+            using (var context = contextProvider.GetContext(domain))
+            {
+                var principal = UserPrincipal.FindByIdentity(context, username);
+
+                if (principal == null)
+                {
+                    var searchedContext = domain ?? context.Name ?? context.ConnectedServer;
+                    log.Info($"A principal identifiable by '{username}' was not found in '{searchedContext}'");
+                    if (username.Contains("@"))
+                    {
+                        return new UserValidationResult("Username not found.  UPN format may not be supported for your domain configuration.");
+                    }
+                    return new UserValidationResult("Username not found");
+                }
+
+                var hToken = IntPtr.Zero;
+                try
+                {
+                    var logon = domain == null ? principal.UserPrincipalName : username;
+                    log.Verbose($"Calling LogonUser(\"{logon}\", \"{domain}\", ...)");
+
+                    if (!LogonUser(logon, domain, password, LOGON32_LOGON_NETWORK, LOGON32_PROVIDER_DEFAULT, out hToken))
+                    {
+                        var error = new Win32Exception();
+                        log.Warn(error, $"Principal '{logon}' (Domain: '{domain}') could not be logged on via WIN32: 0x{error.NativeErrorCode:X8}.");
+
+                        return new UserValidationResult("Active directory login error");
+                    }
+                }
+                finally
+                {
+                    if (hToken != IntPtr.Zero) CloseHandle(hToken);
+                }
+
+                log.Verbose($"Credentials for '{username}' validated, mapped to principal '{principal.UserPrincipalName ?? ("(NTAccount)" + principal.Name)}'");
+
+                return new UserValidationResult(principal, domain);
+            }
+        }
+
+        public UserValidationResult FindByIdentity(string username)
+        {
+            objectNameNormalizer.NormalizeName(username, out username, out var domain);
+
+            using (var context = contextProvider.GetContext(domain))
+            {
+                var principal = UserPrincipal.FindByIdentity(context, username);
+
+                if (principal == null)
+                {
+                    var searchedContext = domain ?? context.Name ?? context.ConnectedServer;
+                    return new UserValidationResult($"A principal identifiable by '{username}' was not found in '{searchedContext}'");
+                }
+                return new UserValidationResult(principal, domain);
+            }
+        }
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        public static extern bool LogonUser(
+            string lpszUsername,
+            string lpszDomain,
+            string lpszPassword,
+            int dwLogonType,
+            int dwLogonProvider,
+            out IntPtr phToken
+        );
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool CloseHandle(IntPtr hObject);
+    }
+}

--- a/source/Server/DirectoryServices/IDirectoryServicesObjectNameNormalizer.cs
+++ b/source/Server/DirectoryServices/IDirectoryServicesObjectNameNormalizer.cs
@@ -1,11 +1,9 @@
-using System.DirectoryServices.AccountManagement;
-
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
 {
     public interface IDirectoryServicesObjectNameNormalizer
     {
         void NormalizeName(string name, out string namePart, out string domainPart);
 
-        string ValidatedUserPrincipalName(UserPrincipal principal, string fallbackUsername, string fallbackDomain);
+        string ValidatedUserPrincipalName(string userPrincipalName, string fallbackUsername, string fallbackDomain);
     }
 }

--- a/source/Server/DirectoryServices/IDirectoryServicesService.cs
+++ b/source/Server/DirectoryServices/IDirectoryServicesService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+
+namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
+{
+    public interface IDirectoryServicesService
+    {
+        UserValidationResult ValidateCredentials(string username, string password, CancellationToken cancellationToken);
+        UserValidationResult FindByIdentity(string username);
+    }
+}

--- a/source/Server/DirectoryServices/UserValidationResult.cs
+++ b/source/Server/DirectoryServices/UserValidationResult.cs
@@ -1,0 +1,42 @@
+using System.DirectoryServices.AccountManagement;
+
+namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
+{
+    public class UserValidationResult
+    {
+        public UserValidationResult(UserPrincipal userPrincipal, string domain)
+            :this(userPrincipal.UserPrincipalName,
+                $"{domain}\\{userPrincipal.SamAccountName}",
+                domain, 
+                string.IsNullOrWhiteSpace(userPrincipal.DisplayName) ? userPrincipal.Name : userPrincipal.DisplayName,
+                userPrincipal.EmailAddress)
+        {
+        }
+
+        public UserValidationResult(string userPrincipalName, string samAccountName, string domain, string displayName, string emailAddress)
+        {
+            UserPrincipalName = userPrincipalName;
+            SamAccountName = samAccountName.Contains("\\") ? samAccountName : $"{domain}\\{samAccountName}";
+            Domain = domain;
+            DisplayName = displayName;
+            EmailAddress = emailAddress;
+
+            Success = true;
+        }
+
+        public UserValidationResult(string validationMessage)
+        {
+            ValidationMessage = validationMessage;
+        }
+
+        public string UserPrincipalName { get; }
+        public string SamAccountName { get; }
+        public string Domain { get; }
+
+        public string DisplayName { get; }
+        public string EmailAddress { get; }
+
+        public bool Success { get; }
+        public string ValidationMessage { get; }
+    }
+}

--- a/source/Server/DirectoryServicesExtension.cs
+++ b/source/Server/DirectoryServicesExtension.cs
@@ -43,6 +43,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices
                 .As<ICanSearchExternalGroups>()
                 .InstancePerDependency();
 
+            builder.RegisterType<DirectoryServicesService>()
+                .As<IDirectoryServicesService>()
+                .InstancePerDependency();
+
             builder.RegisterType<DirectoryServicesCredentialValidator>()
                 .As<IDirectoryServicesCredentialValidator>()
                 .As<IDoesBasicAuthentication>()

--- a/source/Server/Identities/IdentityCreator.cs
+++ b/source/Server/Identities/IdentityCreator.cs
@@ -11,7 +11,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Identiti
         public Identity Create(string email, string upn, string samAccountName, string displayName)
         {
             return new Identity(DirectoryServicesAuthentication.ProviderName)
-                .WithClaim(ClaimDescriptor.EmailClaimType, email, true)
+                .WithClaim(ClaimDescriptor.EmailClaimType, email, false)
                 .WithClaim(UpnClaimType, upn, true)
                 .WithClaim(SamAccountNameClaimType, samAccountName, true)
                 .WithClaim(ClaimDescriptor.DisplayNameClaimType, displayName, false);

--- a/source/Server/Identities/IdentityCreator.cs
+++ b/source/Server/Identities/IdentityCreator.cs
@@ -11,7 +11,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Identiti
         public Identity Create(string email, string upn, string samAccountName, string displayName)
         {
             return new Identity(DirectoryServicesAuthentication.ProviderName)
-                .WithClaim(ClaimDescriptor.EmailClaimType, email, false)
+                .WithClaim(ClaimDescriptor.EmailClaimType, email, true)
                 .WithClaim(UpnClaimType, upn, true)
                 .WithClaim(SamAccountNameClaimType, samAccountName, true)
                 .WithClaim(ClaimDescriptor.DisplayNameClaimType, displayName, false);

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -17,7 +17,7 @@
     <PackageProjectUrl>https://github.com/OctopusDeploy/DirectoryServicesAuthenticationProvider</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Data" Version="3.2.1-enh-email-not-un0002" />
+    <PackageReference Include="Octopus.Data" Version="3.2.1-enh-email-not-un0004" />
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="Autofac" Version="4.6.0" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -17,6 +17,7 @@
     <PackageProjectUrl>https://github.com/OctopusDeploy/DirectoryServicesAuthenticationProvider</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Octopus.Data" Version="3.2.1-enh-email-not-un0002" />
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="Autofac" Version="4.6.0" />


### PR DESCRIPTION
This lets us support multiple AD users with the same email.

To make this work the matching logic has been updated so an exact match drops straight through, but a partial match is checked against the DB record and AD. If the DB user's samAccountName still exists in AD then the user logging in must be a different user.

If the DB user can't be found in AD but we've got a partial match across the other fields then the user has been moved in AD so we update their details.