### PR TITLE
loop through all AD identities, don't assume there's only 1

### DIFF
--- a/source/Server/DirectoryServices/DirectoryServicesCredentialValidator.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesCredentialValidator.cs
@@ -94,11 +94,12 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
             var users = userStore.GetByIdentity(authenticatingIdentity);
 
-            var existingMatchingUser = users.FirstOrDefault(u => u.Identities != null && u.Identities.Any(identity => 
+            var existingMatchingUser = users.SingleOrDefault(u => u.Identities != null && u.Identities.Any(identity => 
                 identity.IdentityProviderName == DirectoryServicesAuthentication.ProviderName &&
                 identity.Equals(authenticatingIdentity)));
             
-            // if all identifiers match, nothing to see here, moving right along
+            // if we can find a user where all identifiers match exactly then we know for sure that's the user
+            // who just logged in.
             if (existingMatchingUser != null)
             {
                 return new AuthenticationUserCreateResult(existingMatchingUser);

--- a/source/Server/DirectoryServices/DirectoryServicesCredentialValidator.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesCredentialValidator.cs
@@ -94,7 +94,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
             var users = userStore.GetByIdentity(authenticatingIdentity);
 
-            var existingMatchingUser = users.SingleOrDefault(u => u.Identities != null && u.Identities.Any(identity => 
+            var existingMatchingUser = users.FirstOrDefault(u => u.Identities != null && u.Identities.Any(identity => 
                 identity.IdentityProviderName == DirectoryServicesAuthentication.ProviderName &&
                 identity.Equals(authenticatingIdentity)));
             
@@ -107,42 +107,45 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             foreach (var user in users)
             {
                 // if we haven't converted the old externalId into the new identity then set it up now
-                var identity = user.Identities.FirstOrDefault(p => p.IdentityProviderName == DirectoryServicesAuthentication.ProviderName);
-                if (identity == null)
+                var anyADIdentity = user.Identities.FirstOrDefault(p => p.IdentityProviderName == DirectoryServicesAuthentication.ProviderName);
+                if (anyADIdentity == null)
                 {
                     return new AuthenticationUserCreateResult(userStore.AddIdentity(user.Id, authenticatingIdentity, cancellationToken));
                 }
 
-                if (identity.Claims[IdentityCreator.SamAccountNameClaimType].Value != samAccountName &&
-                    identity.Claims[IdentityCreator.UpnClaimType].Value != userPrincipalName)
+                foreach (var identity in user.Identities.Where(p => p.IdentityProviderName == DirectoryServicesAuthentication.ProviderName))
                 {
-                    // we found a single other user in our DB that wasn't an exact match, but matched on some fields, so see if that user is still
-                    // in AD
-                    var otherUserPrincipal = directoryServicesService.FindByIdentity(identity.Claims[IdentityCreator.SamAccountNameClaimType].Value);
-
-                    if (!otherUserPrincipal.Success)
+                    if (identity.Claims[IdentityCreator.SamAccountNameClaimType].Value == samAccountName ||
+                        identity.Claims[IdentityCreator.UpnClaimType].Value == userPrincipalName)
                     {
-                        // we couldn't find a match for the existing DB user's SamAccountName in AD, assume their details have been updated in AD
-                        // and we need to modify the existing user in our DB.
-                        identity.Claims[ClaimDescriptor.EmailClaimType].Value = emailAddress;
+                        // if we partially matched but the samAccountName or UPN is the same then this is the same user.
                         identity.Claims[IdentityCreator.UpnClaimType].Value = userPrincipalName;
+                        identity.Claims[ClaimDescriptor.EmailClaimType].Value = emailAddress;
                         identity.Claims[IdentityCreator.SamAccountNameClaimType].Value = samAccountName;
                         identity.Claims[ClaimDescriptor.DisplayNameClaimType].Value = displayName;
 
                         return new AuthenticationUserCreateResult(userStore.UpdateIdentity(user.Id, identity, cancellationToken));
                     }
-                    
-                    // otherUserPrincipal still exists in AD, so what we have here is a new user
-                }
-                else 
-                {
-                    // if we partially matched but the samAccountName or UPN is the same then this is the same user.
-                    identity.Claims[IdentityCreator.UpnClaimType].Value = userPrincipalName;
-                    identity.Claims[ClaimDescriptor.EmailClaimType].Value = emailAddress;
-                    identity.Claims[IdentityCreator.SamAccountNameClaimType].Value = samAccountName;
-                    identity.Claims[ClaimDescriptor.DisplayNameClaimType].Value = displayName;
+                    else
+                    {
+                        // we found a single other user in our DB that wasn't an exact match, but matched on some fields, so see if that user is still
+                        // in AD
+                        var otherUserPrincipal = directoryServicesService.FindByIdentity(identity.Claims[IdentityCreator.SamAccountNameClaimType].Value);
 
-                    return new AuthenticationUserCreateResult(userStore.UpdateIdentity(user.Id, identity, cancellationToken));
+                        if (!otherUserPrincipal.Success)
+                        {
+                            // we couldn't find a match for the existing DB user's SamAccountName in AD, assume their details have been updated in AD
+                            // and we need to modify the existing user in our DB.
+                            identity.Claims[ClaimDescriptor.EmailClaimType].Value = emailAddress;
+                            identity.Claims[IdentityCreator.UpnClaimType].Value = userPrincipalName;
+                            identity.Claims[IdentityCreator.SamAccountNameClaimType].Value = samAccountName;
+                            identity.Claims[ClaimDescriptor.DisplayNameClaimType].Value = displayName;
+
+                            return new AuthenticationUserCreateResult(userStore.UpdateIdentity(user.Id, identity, cancellationToken));
+                        }
+
+                        // otherUserPrincipal still exists in AD, so what we have here is a new user
+                    }
                 }
             }
 


### PR DESCRIPTION
From customer data examples, it has been possible that the user records can end up with multiple AD identities, and then new users get created when they shouldn't because we only check the first identity we find.

This change removes the single AD Identity assumption from the login checks for existing users. 

Relates to OctopusDeploy/Issues#5613