### PR TITLE
Update to Invoker infrastructure

### DIFF
--- a/source/Server/DirectoryServicesApi.cs
+++ b/source/Server/DirectoryServicesApi.cs
@@ -11,8 +11,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices
         public const string ApiExternalUsersSearch = "/api/externalusers/directoryServices{?partialName}";
 
         public DirectoryServicesApi(
-            Func<SecuredAsyncActionInvoker<ListSecurityGroupsAction, IDirectoryServicesConfigurationStore>> listSecurityGroupsActionInvokerFactory,
-            Func<SecuredAsyncActionInvoker<UserLookupAction, IDirectoryServicesConfigurationStore>> userLookupActionInvokerFactory)
+            Func<SecuredWhenEnabledAsyncActionInvoker<ListSecurityGroupsAction, IDirectoryServicesConfigurationStore>> listSecurityGroupsActionInvokerFactory,
+            Func<SecuredWhenEnabledAsyncActionInvoker<UserLookupAction, IDirectoryServicesConfigurationStore>> userLookupActionInvokerFactory)
         {
             Add("GET", ApiExternalGroupsSearch, listSecurityGroupsActionInvokerFactory().ExecuteAsync);
             Add("GET", ApiExternalUsersSearch, userLookupActionInvokerFactory().ExecuteAsync);

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -17,7 +17,7 @@
     <PackageProjectUrl>https://github.com/OctopusDeploy/DirectoryServicesAuthenticationProvider</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Data" Version="4.1.0" />
+    <PackageReference Include="Octopus.Data" Version="4.2.5" />
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="Autofac" Version="4.6.0" />
@@ -25,7 +25,7 @@
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.1.1" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.3.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-bug-connectiont-0002" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.1.1" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-bug-connectiont-0002" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />


### PR DESCRIPTION
The Invokers now allows execution when the extension is disabled, if required. This extension has endpoints that need to only execute when Enabled, so it needed to change to use the updated Invoker