### PR TITLE
Correct WWW-Authenticate Headers when using `IntegratedAuthentication` mode

### DIFF
--- a/source/Server/Configuration/DirectoryServicesConfigurationResource.cs
+++ b/source/Server/Configuration/DirectoryServicesConfigurationResource.cs
@@ -9,8 +9,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
     {
 
         public const string ActiveDirectoryContainerDescription = "Set the active directory container used for authentication.";
-
-        public const string AuthenticationSchemeDescription = "When Domain authentication is used, specifies the scheme (Basic, Digest, IntegratedWindowsAuthentication, Negotiate, Ntlm). You will need to restart all Octopus Server nodes in your cluster for these changes to take effect.";
+        
+        public const string AuthenticationSchemeDescription = "When Domain authentication is used, specifies the scheme (Basic, Digest, IntegratedWindowsAuthentication, Negotiate, Ntlm). You will need to restart all Octopus Server nodes in your cluster for these changes to take effect. Please note that using Negotiate or IntegratedWindowsAuthentication [may require additional server configuration](https://g.octopushq.com/AuthAD) in order to work correctly.";
 
         public const string AllowFormsAuthenticationForDomainUsersDescription = "When Domain authentication is used, specifies whether the HTML-based username/password form can be used to sign in.";
 

--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationHost.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationHost.cs
@@ -114,7 +114,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
                 case System.Net.AuthenticationSchemes.Negotiate:
                     return AuthenticationSchemes.Negotiate;
                 case System.Net.AuthenticationSchemes.IntegratedWindowsAuthentication:
-                    return AuthenticationSchemes.Kerberos;
+                    return AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM;
             }
             return AuthenticationSchemes.None;
         }

--- a/source/Server/IntegratedAuthentication/IntegratedChallengeCoordinator.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedChallengeCoordinator.cs
@@ -38,7 +38,9 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
                 }
                 
                 // if we've seen this connection before and the user still isn't set then something has gone
-                // wrong with the challenge. Most likely due to cross domains now we're NETCore, https://github.com/OctopusDeploy/Issues/issues/6265
+                // wrong with the challenge. Most likely to us using HTTPS.sys https://docs.microsoft.com/en-us/aspnet/core/security/authentication/windowsauth?view=aspnetcore-3.1&tabs=visual-studio#httpsys
+                // User mode authentication isn't supported with Kerberos and HTTP.sys. The machine account must be used to decrypt the Kerberos token/ticket that's obtained from Active Directory
+                // SPN KB: https://support.microsoft.com/en-us/help/929650/how-to-use-spns-when-you-configure-web-applications-that-are-hosted-on
                 var stateRedirectAfterLoginTo = state.RedirectAfterLoginTo;
 
                 // this matches an error structure that the portal currently uses. It is not something the server


### PR DESCRIPTION
This PR intends to correct the header behaviour when choosing `IntegratedAuthentication` and to provide some additional guidance when making that selection.

## Before 
Prior to using .net core we were simply relying on the value set by `AuthenticationScheme.IntegratedWindowsAuthentication` which under the hood uses `Negotiate | NTLM`

![image](https://user-images.githubusercontent.com/579657/80935988-5f6eba80-8e0e-11ea-9c1f-cccf985764f4.png)  

This would result in a header like `WWW-Authenticate: Negotiate, NTLM`.

However with the move to .netcore we changed this behaviour to use a header value of `WWW-Authenticate: Kerberos` which doesn't appear to be valid.

## After

WWW-Authenticate headers should be sent to use the following values `Negotiate, NTLM`.

## Details
[Internal ticket](https://trello.com/c/62riwP29/3180-unable-to-sign-in-with-domain-account-after-upgrading-to-v2020)

Update to documentation: https://github.com/OctopusDeploy/docs/pull/725