### PR TITLE
Enabling Nullable Reference Types

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -21,7 +21,7 @@ var publishDir = "./publish";
 var localPackagesDir = "../LocalPackages";
 var artifactsDir = "./artifacts";
 var assetDir = "./BuildAssets";
-var netstd = "/bin/Release/netstandard2.0/";
+var netstd = "/bin/Release/netstandard2.1/";
 
 var gitVersionInfo = GitVersion(new GitVersionSettings {
     OutputType = GitVersionOutput.Json

--- a/source/DirectoryServices.Tests/ActiveDirectoryMembershipTests.cs
+++ b/source/DirectoryServices.Tests/ActiveDirectoryMembershipTests.cs
@@ -14,12 +14,11 @@ namespace DirectoryServices.Tests
         [TestCase("EXAMPLE\\joe", "joe", "EXAMPLE")]
         public void CredentialsAreNormalized(string rawUsername, string usedUsername, string usedDomain)
         {
-            string usernamePart, domainPart;
             var log = Substitute.For<ILog>();
             var credentialNormalizer = new DirectoryServicesObjectNameNormalizer(log);
-            credentialNormalizer.NormalizeName(rawUsername, out usernamePart, out domainPart);
-            Assert.AreEqual(usedUsername, usernamePart);
-            Assert.AreEqual(usedDomain, domainPart);
+            var domainUser = credentialNormalizer.NormalizeName(rawUsername);
+            Assert.AreEqual(usedUsername, domainUser.NormalizedName);
+            Assert.AreEqual(usedDomain, domainUser.Domain);
         }
     }
 }

--- a/source/DirectoryServices.Tests/CredentialValidatorTests.cs
+++ b/source/DirectoryServices.Tests/CredentialValidatorTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using NSubstitute;
 using NUnit.Framework;
+using Octopus.Data;
 using Octopus.Data.Model;
 using Octopus.Data.Model.User;
 using Octopus.Data.Storage.User;
@@ -36,7 +37,7 @@ namespace DirectoryServices.Tests
             updateableUserStore = Substitute.For<IUpdateableUserStore>();
 
             directoryServicesService = Substitute.For<IDirectoryServicesService>();
-            
+
             var log = Substitute.For<ILog>();
 
             identityCreator = new IdentityCreator();
@@ -55,8 +56,8 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("invalidUser", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeFalse();
-            result.ErrorString.ShouldBe("User not found");
+            result.ShouldBeAssignableTo<FailureResult>();
+            ((FailureResult)result).ErrorString.ShouldBe("User not found");
             updateableUserStore.DidNotReceive().Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
         }
 
@@ -72,7 +73,7 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("existingUser", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeTrue();
+            result.ShouldBeOfType<ResultFromExtension<IUser>>();
             updateableUserStore.DidNotReceive().UpdateIdentity(Arg.Any<string>(), Arg.Any<Identity>(), CancellationToken.None);
         }
 
@@ -90,7 +91,7 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("existingUser1@test.com", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeTrue();
+            result.ShouldBeOfType<ResultFromExtension<IUser>>();
             updateableUserStore.Received(1).UpdateIdentity(Arg.Any<string>(), Arg.Any<Identity>(), CancellationToken.None);
         }
 
@@ -108,7 +109,7 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("newUser", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeTrue();
+            result.ShouldBeOfType<ResultFromExtension<IUser>>();
             updateableUserStore.Received(1).Create("newUser@test.com", Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None, Arg.Any<ProviderUserGroups>(), Arg.Any<IEnumerable<Identity>>());
         }
 
@@ -129,7 +130,7 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("newUser", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeTrue();
+            result.ShouldBeOfType<ResultFromExtension<IUser>>();
             updateableUserStore.Received(1).Create("newUser@test.com", Arg.Any<string>(), "tester@test.com", CancellationToken.None, Arg.Any<ProviderUserGroups>(), Arg.Any<IEnumerable<Identity>>());
         }
 
@@ -146,7 +147,7 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("existingUser2", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeTrue();
+            result.ShouldBeOfType<ResultFromExtension<IUser>>();
             updateableUserStore.DidNotReceive().Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
         }
 
@@ -162,8 +163,8 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("newUser", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeFalse();
-            result.ErrorString.ShouldBe("User could not be located and auto user creation is not enabled.");
+            result.ShouldBeAssignableTo<FailureResult>();
+            ((FailureResult)result).ErrorString.ShouldBe("User could not be located and auto user creation is not enabled.");
         }
 
         [Test]
@@ -180,7 +181,7 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("Domain2\\newUser", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeTrue();
+            result.ShouldBeOfType<ResultFromExtension<IUser>>();
             updateableUserStore.Received(1).Create("newUser@domain2.com", Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None, Arg.Any<ProviderUserGroups>(), Arg.Any<IEnumerable<Identity>>());
         }
 
@@ -196,7 +197,7 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("existingUser", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeTrue();
+            result.ShouldBeOfType<ResultFromExtension<IUser>>();
             updateableUserStore.Received(1).UpdateIdentity("Users-100", Arg.Any<Identity>(), CancellationToken.None);
             updateableUserStore.DidNotReceive().Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
         }
@@ -213,7 +214,7 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("existingUserWithNewSam", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeTrue();
+            result.ShouldBeOfType<ResultFromExtension<IUser>>();
             updateableUserStore.Received(1).UpdateIdentity("Users-100", Arg.Any<Identity>(), CancellationToken.None);
             updateableUserStore.DidNotReceive().Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
         }
@@ -232,7 +233,7 @@ namespace DirectoryServices.Tests
 
             var result = validator.ValidateCredentials("existingUserWithNewSam", "testPassword", CancellationToken.None);
 
-            result.WasSuccessful.ShouldBeTrue();
+            result.ShouldBeOfType<ResultFromExtension<IUser>>();
             updateableUserStore.Received(1).UpdateIdentity("Users-100", Arg.Any<Identity>(), CancellationToken.None);
             updateableUserStore.DidNotReceive().Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
         }

--- a/source/DirectoryServices.Tests/DirectoryServices.Tests.csproj
+++ b/source/DirectoryServices.Tests/DirectoryServices.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Assent" Version="1.3.0" />

--- a/source/DirectoryServices.Tests/DirectoryServicesExternalSecurityGroupLocatorTests.cs
+++ b/source/DirectoryServices.Tests/DirectoryServicesExternalSecurityGroupLocatorTests.cs
@@ -29,11 +29,15 @@ namespace DirectoryServices.Tests
             var contextProvider = Substitute.For<IDirectoryServicesContextProvider>();
 
             userPrincipalFinder = Substitute.For<IUserPrincipalFinder>();
+
+            var directoryServicesObjectNameNormalizer = Substitute.For<IDirectoryServicesObjectNameNormalizer>();
+            directoryServicesObjectNameNormalizer.NormalizeName(Arg.Any<string>())
+                .Returns(x => new DomainUser(null, ((string)x.Args()[0])));
             
             locator = new DirectoryServicesExternalSecurityGroupLocator(
                 log,
                 contextProvider,
-                Substitute.For<IDirectoryServicesObjectNameNormalizer>(),
+                directoryServicesObjectNameNormalizer,
                 configurationStore,
                 userPrincipalFinder
             );

--- a/source/Server/Configuration/DirectoryServicesConfiguration.cs
+++ b/source/Server/Configuration/DirectoryServicesConfiguration.cs
@@ -15,7 +15,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
         /// <summary>
         /// Gets or sets the active directory container, if not specified default container is used
         /// </summary>
-        public string ActiveDirectoryContainer { get; set; }
+        public string? ActiveDirectoryContainer { get; set; }
 
         /// <summary>
         /// Gets or sets the authentication scheme to use when authentication Domain users.

--- a/source/Server/Configuration/DirectoryServicesConfigurationResource.cs
+++ b/source/Server/Configuration/DirectoryServicesConfigurationResource.cs
@@ -21,7 +21,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
         [DisplayName("Active Directory Container")]
         [Description(ActiveDirectoryContainerDescription)]
         [Writeable]
-        public string ActiveDirectoryContainer { get; set; }
+        public string? ActiveDirectoryContainer { get; set; }
 
         [DisplayName("Authentication Scheme")]
         [Description(AuthenticationSchemeDescription)]

--- a/source/Server/Configuration/DirectoryServicesConfigurationSettings.cs
+++ b/source/Server/Configuration/DirectoryServicesConfigurationSettings.cs
@@ -24,7 +24,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
             var isEnabled = ConfigurationDocumentStore.GetIsEnabled();
 
             yield return new ConfigurationValue<bool>("Octopus.WebPortal.ActiveDirectoryIsEnabled", isEnabled, isEnabled, "Is Enabled");
-            yield return new ConfigurationValue<string>("Octopus.WebPortal.ActiveDirectoryContainer", ConfigurationDocumentStore.GetActiveDirectoryContainer(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetActiveDirectoryContainer()), "Active Directory Container");
+            yield return new ConfigurationValue<string?>("Octopus.WebPortal.ActiveDirectoryContainer", ConfigurationDocumentStore.GetActiveDirectoryContainer(), isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetActiveDirectoryContainer()), "Active Directory Container");
             yield return new ConfigurationValue<string>("Octopus.WebPortal.AuthenticationScheme", ConfigurationDocumentStore.GetAuthenticationScheme().ToString(), isEnabled, "Authentication Scheme");
             yield return new ConfigurationValue<bool>("Octopus.WebPortal.AllowFormsAuthenticationForDomainUsers", ConfigurationDocumentStore.GetAllowFormsAuthenticationForDomainUsers(), isEnabled, "Allow forms authentication");
             yield return new ConfigurationValue<bool>("Octopus.WebPortal.ExternalSecurityGroupsDisabled", ConfigurationDocumentStore.GetAreSecurityGroupsEnabled(), isEnabled, "Security groups enabled");

--- a/source/Server/Configuration/DirectoryServicesConfigurationStore.cs
+++ b/source/Server/Configuration/DirectoryServicesConfigurationStore.cs
@@ -18,12 +18,12 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
         public string ChallengePath => DirectoryServicesConstants.ChallengePath;
         public AuthenticationSchemes AuthenticationScheme => GetIsEnabled() ? GetAuthenticationScheme() : AuthenticationSchemes.Anonymous;
 
-        public string GetActiveDirectoryContainer()
+        public string? GetActiveDirectoryContainer()
         {
             return GetProperty(doc => doc.ActiveDirectoryContainer);
         }
 
-        public void SetActiveDirectoryContainer(string activeDirectoryContainer)
+        public void SetActiveDirectoryContainer(string? activeDirectoryContainer)
         {
             SetProperty(doc => doc.ActiveDirectoryContainer = activeDirectoryContainer);
         }

--- a/source/Server/Configuration/IDirectoryServicesConfigurationStore.cs
+++ b/source/Server/Configuration/IDirectoryServicesConfigurationStore.cs
@@ -5,8 +5,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Configur
 {
     interface IDirectoryServicesConfigurationStore : IExtensionConfigurationStore<DirectoryServicesConfiguration>
     {
-        string GetActiveDirectoryContainer();
-        void SetActiveDirectoryContainer(string activeDirectoryContainer);
+        string? GetActiveDirectoryContainer();
+        void SetActiveDirectoryContainer(string? activeDirectoryContainer);
 
         AuthenticationSchemes GetAuthenticationScheme();
         void SetAuthenticationScheme(AuthenticationSchemes scheme);

--- a/source/Server/DirectoryServices/DirectoryServicesContextProvider.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesContextProvider.cs
@@ -13,7 +13,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.adConfiguration = adConfiguration;
         }
 
-        public PrincipalContext GetContext(string domain)
+        public PrincipalContext GetContext(string? domain)
         {
             var adContainer = adConfiguration.Value.GetActiveDirectoryContainer();
             adContainer = string.IsNullOrEmpty(adContainer) ? null : adContainer;

--- a/source/Server/DirectoryServices/DirectoryServicesCredentialValidator.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesCredentialValidator.cs
@@ -72,7 +72,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             return GetOrCreateUser(result, result.UserPrincipalName, result.Domain ?? EnvironmentUserDomainName, cancellationToken);
         }
 
-        internal AuthenticationUserCreateResult GetOrCreateUser(UserValidationResult principal, string fallbackUsername, string fallbackDomain, CancellationToken cancellationToken)
+        internal AuthenticationUserCreateResult GetOrCreateUser(UserValidationResult principal, string? fallbackUsername, string? fallbackDomain, CancellationToken cancellationToken)
         {
             var userPrincipalName = objectNameNormalizer.ValidatedUserPrincipalName(principal.UserPrincipalName, fallbackUsername, fallbackDomain);
 

--- a/source/Server/DirectoryServices/DirectoryServicesCredentialValidator.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesCredentialValidator.cs
@@ -38,6 +38,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.directoryServicesService = directoryServicesService;
         }
 
+        public string IdentityProviderName => DirectoryServicesAuthentication.ProviderName;
+
         public int Priority => 100;
 
         public ResultFromExtension<IUser> ValidateCredentials(string username, string password, CancellationToken cancellationToken)
@@ -77,14 +79,14 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         {
             var userPrincipalName = objectNameNormalizer.ValidatedUserPrincipalName(principal.UserPrincipalName, fallbackUsername, fallbackDomain);
 
-            var samAccountName = principal.SamAccountName;
+            var samAccountName = principal.SamAccountName ?? string.Empty;
             if (!string.IsNullOrWhiteSpace(fallbackDomain) && !samAccountName.Contains("\\"))
             {
                 samAccountName = fallbackDomain + @"\" + samAccountName;
             }
 
-            var displayName = principal.DisplayName;
-            var emailAddress = principal.EmailAddress;
+            var displayName = principal.DisplayName ?? string.Empty;
+            var emailAddress = principal.EmailAddress ?? string.Empty;
 
             if (string.IsNullOrWhiteSpace(samAccountName))
             {

--- a/source/Server/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
@@ -33,13 +33,15 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.userPrincipalFinder = userPrincipalFinder;
         }
 
+        public string IdentityProviderName => DirectoryServicesAuthentication.ProviderName;
+
         public ResultFromExtension<ExternalSecurityGroupResult> Search(string name, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled() || !configurationStore.GetAreSecurityGroupsEnabled())
                 return ResultFromExtension<ExternalSecurityGroupResult>.ExtensionDisabled();
 
             var groups = FindGroups(name, cancellationToken);
-            var result = new ExternalSecurityGroupResult(DirectoryServicesAuthentication.ProviderName, groups);
+            var result = new ExternalSecurityGroupResult(groups);
 
             return ResultFromExtension<ExternalSecurityGroupResult>.Success(result);
         }

--- a/source/Server/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
@@ -7,6 +7,7 @@ using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.Configuration;
 using Octopus.Server.Extensibility.Authentication.Extensions;
 using Octopus.Server.Extensibility.Authentication.HostServices;
+using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
 {
@@ -32,15 +33,15 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.userPrincipalFinder = userPrincipalFinder;
         }
 
-        public ExternalSecurityGroupResult? Search(string name, CancellationToken cancellationToken)
+        public ResultFromExtension<ExternalSecurityGroupResult> Search(string name, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled() || !configurationStore.GetAreSecurityGroupsEnabled())
-                return null;
+                return ResultFromExtension<ExternalSecurityGroupResult>.ExtensionDisabled();
 
             var groups = FindGroups(name, cancellationToken);
             var result = new ExternalSecurityGroupResult(DirectoryServicesAuthentication.ProviderName, groups);
 
-            return result;
+            return ResultFromExtension<ExternalSecurityGroupResult>.Success(result);
         }
 
         ExternalSecurityGroup[] FindGroups(string name, CancellationToken cancellationToken)

--- a/source/Server/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
@@ -35,7 +35,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
         public string IdentityProviderName => DirectoryServicesAuthentication.ProviderName;
 
-        public ResultFromExtension<ExternalSecurityGroupResult> Search(string name, CancellationToken cancellationToken)
+        public IResultFromExtension<ExternalSecurityGroupResult> Search(string name, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled() || !configurationStore.GetAreSecurityGroupsEnabled())
                 return ResultFromExtension<ExternalSecurityGroupResult>.ExtensionDisabled();
@@ -130,7 +130,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
                     // Reads just the groups they are a member of - more reliable but not ideal
                     using (var principal = userPrincipalFinder.FindByIdentity(context, samAccountName))
                         ReadUserGroups(principal, groups, cancellationToken);
-                    
+
                     return new DirectoryServicesExternalSecurityGroupLocatorResult(groups);
                 }
             }

--- a/source/Server/DirectoryServices/DirectoryServicesExternalSecurityGroupLocatorResult.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesExternalSecurityGroupLocatorResult.cs
@@ -14,7 +14,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             GroupsIds = groupsIds;
         }
 
-        public bool WasAbleToRetrieveGroups { get; set; }
-        public IList<string> GroupsIds { get; set; }
+        public bool WasAbleToRetrieveGroups { get; }
+        public IList<string>? GroupsIds { get; }
     }
 }

--- a/source/Server/DirectoryServices/DirectoryServicesService.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesService.cs
@@ -40,17 +40,17 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         {
             log.Verbose($"Validating credentials provided for '{username}'...");
 
-            objectNameNormalizer.NormalizeName(username, out username, out var domain);
+            var domainUser = objectNameNormalizer.NormalizeName(username);
 
-            using (var context = contextProvider.GetContext(domain))
+            using (var context = contextProvider.GetContext(domainUser.Domain))
             {
-                var principal = UserPrincipal.FindByIdentity(context, username);
+                var principal = UserPrincipal.FindByIdentity(context, domainUser.NormalizedName);
 
                 if (principal == null)
                 {
-                    var searchedContext = domain ?? context.Name ?? context.ConnectedServer;
+                    var searchedContext = domainUser.Domain ?? context.Name ?? context.ConnectedServer;
                     log.Info($"A principal identifiable by '{username}' was not found in '{searchedContext}'");
-                    if (username.Contains("@"))
+                    if (domainUser.NormalizedName.Contains("@"))
                     {
                         return new UserValidationResult("Invalid username or password.  UPN format may not be supported for your domain configuration.");
                     }
@@ -60,13 +60,13 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
                 var hToken = IntPtr.Zero;
                 try
                 {
-                    var logon = domain == null ? principal.UserPrincipalName : username;
-                    log.Verbose($"Calling LogonUser(\"{logon}\", \"{domain}\", ...)");
+                    var logon = domainUser.Domain == null ? principal.UserPrincipalName : domainUser.NormalizedName;
+                    log.Verbose($"Calling LogonUser(\"{logon}\", \"{domainUser.Domain}\", ...)");
 
-                    if (!LogonUser(logon, domain, password, LOGON32_LOGON_NETWORK, LOGON32_PROVIDER_DEFAULT, out hToken))
+                    if (!LogonUser(logon, domainUser.Domain, password, LOGON32_LOGON_NETWORK, LOGON32_PROVIDER_DEFAULT, out hToken))
                     {
                         var error = new Win32Exception();
-                        log.Warn(error, $"Principal '{logon}' (Domain: '{domain}') could not be logged on via WIN32: 0x{error.NativeErrorCode:X8}.");
+                        log.Warn(error, $"Principal '{logon}' (Domain: '{domainUser.Domain}') could not be logged on via WIN32: 0x{error.NativeErrorCode:X8}.");
 
                         return new UserValidationResult("Invalid username or password.");
                     }
@@ -78,31 +78,31 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
                 log.Verbose($"Credentials for '{username}' validated, mapped to principal '{principal.UserPrincipalName ?? ("(NTAccount)" + principal.Name)}'");
 
-                return new UserValidationResult(principal, domain);
+                return new UserValidationResult(principal, domainUser.Domain);
             }
         }
 
         public UserValidationResult FindByIdentity(string username)
         {
-            objectNameNormalizer.NormalizeName(username, out username, out var domain);
+            var domainUser = objectNameNormalizer.NormalizeName(username);
 
-            using (var context = contextProvider.GetContext(domain))
+            using (var context = contextProvider.GetContext(domainUser.Domain))
             {
-                var principal = UserPrincipal.FindByIdentity(context, username);
+                var principal = UserPrincipal.FindByIdentity(context, domainUser.NormalizedName);
 
                 if (principal == null)
                 {
-                    var searchedContext = domain ?? context.Name ?? context.ConnectedServer;
+                    var searchedContext = domainUser.Domain ?? context.Name ?? context.ConnectedServer;
                     return new UserValidationResult($"A principal identifiable by '{username}' was not found in '{searchedContext}'");
                 }
-                return new UserValidationResult(principal, domain);
+                return new UserValidationResult(principal, domainUser.Domain);
             }
         }
 
         [DllImport("advapi32.dll", SetLastError = true)]
         public static extern bool LogonUser(
             string lpszUsername,
-            string lpszDomain,
+            string? lpszDomain,
             string lpszPassword,
             int dwLogonType,
             int dwLogonProvider,

--- a/source/Server/DirectoryServices/DirectoryServicesUserCreationFromPrincipal.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesUserCreationFromPrincipal.cs
@@ -22,10 +22,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
         public string IdentityProviderName => DirectoryServicesAuthentication.ProviderName;
 
-        public ResultFromExtension<IUser> GetOrCreateUser(IPrincipal principal, CancellationToken cancellationToken)
+        public IResultFromExtension<IUser> GetOrCreateUser(IPrincipal principal, CancellationToken cancellationToken)
         {
-            return !configurationStore.GetIsEnabled() ? 
-                ResultFromExtension<IUser>.ExtensionDisabled() : 
+            return !configurationStore.GetIsEnabled() ?
+                ResultFromExtension<IUser>.ExtensionDisabled() :
                 credentialValidator.GetOrCreateUser(principal.Identity.Name, cancellationToken);
         }
     }

--- a/source/Server/DirectoryServices/DirectoryServicesUserCreationFromPrincipal.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesUserCreationFromPrincipal.cs
@@ -20,6 +20,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.credentialValidator = credentialValidator;
         }
 
+        public string IdentityProviderName => DirectoryServicesAuthentication.ProviderName;
+
         public ResultFromExtension<IUser> GetOrCreateUser(IPrincipal principal, CancellationToken cancellationToken)
         {
             return !configurationStore.GetIsEnabled() ? 

--- a/source/Server/DirectoryServices/DirectoryServicesUserCreationFromPrincipal.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesUserCreationFromPrincipal.cs
@@ -1,8 +1,9 @@
 ﻿using System.Security.Principal;
 using System.Threading;
+using Octopus.Data.Model.User;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.Configuration;
 using Octopus.Server.Extensibility.Authentication.Extensions;
-using Octopus.Server.Extensibility.Authentication.Storage.User;
+using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
 {
@@ -19,10 +20,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.credentialValidator = credentialValidator;
         }
 
-        public AuthenticationUserCreateResult GetOrCreateUser(IPrincipal principal, CancellationToken cancellationToken)
+        public ResultFromExtension<IUser> GetOrCreateUser(IPrincipal principal, CancellationToken cancellationToken)
         {
             return !configurationStore.GetIsEnabled() ? 
-                new AuthenticationUserCreateResult() : 
+                ResultFromExtension<IUser>.ExtensionDisabled() : 
                 credentialValidator.GetOrCreateUser(principal.Identity.Name, cancellationToken);
         }
     }

--- a/source/Server/DirectoryServices/DomainUser.cs
+++ b/source/Server/DirectoryServices/DomainUser.cs
@@ -1,0 +1,14 @@
+namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
+{
+    class DomainUser
+    {
+        public DomainUser(string? domain, string normalizedName)
+        {
+            Domain = domain;
+            NormalizedName = normalizedName;
+        }
+
+        public string? Domain { get; }
+        public string NormalizedName { get; }
+    }
+}

--- a/source/Server/DirectoryServices/GroupRetriever.cs
+++ b/source/Server/DirectoryServices/GroupRetriever.cs
@@ -26,6 +26,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.groupLocator = groupLocator;
         }
 
+        public string IdentityProviderName => DirectoryServicesAuthentication.ProviderName;
+
         public ResultFromExtension<ExternalGroupResult> Read(IUser user, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled() ||

--- a/source/Server/DirectoryServices/GroupRetriever.cs
+++ b/source/Server/DirectoryServices/GroupRetriever.cs
@@ -68,7 +68,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
                 return ResultFromExtension<ExternalGroupResult>.Failed($"Couldn't retrieve groups for user {user.Username}");
             }
 
-            return ResultFromExtension<ExternalGroupResult>.Success(new ExternalGroupResult(DirectoryServicesAuthentication.ProviderName, newGroups.Select(g => g).ToArray()));
+            return ResultFromExtension<ExternalGroupResult>.Success(new ExternalGroupResult(newGroups.Select(g => g).ToArray()));
         }
     }
 }

--- a/source/Server/DirectoryServices/GroupRetriever.cs
+++ b/source/Server/DirectoryServices/GroupRetriever.cs
@@ -6,6 +6,7 @@ using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.Configuration;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.Identities;
 using Octopus.Server.Extensibility.Authentication.Extensions;
+using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
 {
@@ -25,15 +26,15 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.groupLocator = groupLocator;
         }
 
-        public ExternalGroupResult Read(IUser user, CancellationToken cancellationToken)
+        public ResultFromExtension<ExternalGroupResult> Read(IUser user, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled() ||
                 !configurationStore.GetAreSecurityGroupsEnabled())
-                return new ExternalGroupResult(DirectoryServicesAuthentication.ProviderName, "Not enabled");
+                return ResultFromExtension<ExternalGroupResult>.ExtensionDisabled();
             if (user.Username == User.GuestLogin)
-                return new ExternalGroupResult(DirectoryServicesAuthentication.ProviderName, "Not valid for Guest user");
+                return ResultFromExtension<ExternalGroupResult>.Failed("Not valid for Guest user");
             if (user.Identities.All(p => p.IdentityProviderName != DirectoryServicesAuthentication.ProviderName))
-                return new ExternalGroupResult(DirectoryServicesAuthentication.ProviderName, "No identities matching this provider");
+                return ResultFromExtension<ExternalGroupResult>.Failed("No identities matching this provider");
 
             // if the user has multiple, unique identities assigned then the group list should be the distinct union of the groups from
             // all of the identities
@@ -62,10 +63,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             if (!wasAbleToRetrieveSomeGroups)
             {
                 log.ErrorFormat("Couldn't retrieve groups for user {0}", user.Username);
-                return new ExternalGroupResult(DirectoryServicesAuthentication.ProviderName, $"Couldn't retrieve groups for user {user.Username}");
+                return ResultFromExtension<ExternalGroupResult>.Failed($"Couldn't retrieve groups for user {user.Username}");
             }
 
-            return new ExternalGroupResult(DirectoryServicesAuthentication.ProviderName, newGroups.Select(g => g).ToArray());
+            return ResultFromExtension<ExternalGroupResult>.Success(new ExternalGroupResult(DirectoryServicesAuthentication.ProviderName, newGroups.Select(g => g).ToArray()));
         }
     }
 }

--- a/source/Server/DirectoryServices/GroupRetriever.cs
+++ b/source/Server/DirectoryServices/GroupRetriever.cs
@@ -28,7 +28,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
         public string IdentityProviderName => DirectoryServicesAuthentication.ProviderName;
 
-        public ResultFromExtension<ExternalGroupResult> Read(IUser user, CancellationToken cancellationToken)
+        public IResultFromExtension<ExternalGroupResult> Read(IUser user, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled() ||
                 !configurationStore.GetAreSecurityGroupsEnabled())

--- a/source/Server/DirectoryServices/GroupRetriever.cs
+++ b/source/Server/DirectoryServices/GroupRetriever.cs
@@ -18,7 +18,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
         public GroupRetriever(
             ILog log,
-            IDirectoryServicesConfigurationStore configurationStore, 
+            IDirectoryServicesConfigurationStore configurationStore,
             IDirectoryServicesExternalSecurityGroupLocator groupLocator)
         {
             this.log = log;
@@ -47,6 +47,9 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             {
                 var samAccountName = adIdentity.Claims[IdentityCreator.SamAccountNameClaimType].Value;
 
+                if (string.IsNullOrWhiteSpace(samAccountName))
+                    continue;
+
                 var result = groupLocator.GetGroupIdsForUser(samAccountName, cancellationToken);
                 if (result.WasAbleToRetrieveGroups)
                 {
@@ -54,7 +57,9 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
                     {
                         newGroups.Add(groupId);
                     }
+
                     wasAbleToRetrieveSomeGroups = true;
+
                 }
                 else
                 {

--- a/source/Server/DirectoryServices/IDirectoryServicesContextProvider.cs
+++ b/source/Server/DirectoryServices/IDirectoryServicesContextProvider.cs
@@ -4,6 +4,6 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 {
     interface IDirectoryServicesContextProvider
     {
-        PrincipalContext GetContext(string domain);
+        PrincipalContext GetContext(string? domain);
     }
 }

--- a/source/Server/DirectoryServices/IDirectoryServicesCredentialValidator.cs
+++ b/source/Server/DirectoryServices/IDirectoryServicesCredentialValidator.cs
@@ -1,11 +1,12 @@
 using System.Threading;
+using Octopus.Data.Model.User;
 using Octopus.Server.Extensibility.Authentication.Extensions;
-using Octopus.Server.Extensibility.Authentication.Storage.User;
+using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
 {
     interface IDirectoryServicesCredentialValidator : IDoesBasicAuthentication
     {
-        AuthenticationUserCreateResult GetOrCreateUser(string username, CancellationToken cancellationToken);
+        ResultFromExtension<IUser> GetOrCreateUser(string username, CancellationToken cancellationToken);
     }
 }

--- a/source/Server/DirectoryServices/IDirectoryServicesCredentialValidator.cs
+++ b/source/Server/DirectoryServices/IDirectoryServicesCredentialValidator.cs
@@ -7,6 +7,6 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 {
     interface IDirectoryServicesCredentialValidator : IDoesBasicAuthentication
     {
-        ResultFromExtension<IUser> GetOrCreateUser(string username, CancellationToken cancellationToken);
+        IResultFromExtension<IUser> GetOrCreateUser(string username, CancellationToken cancellationToken);
     }
 }

--- a/source/Server/DirectoryServices/IDirectoryServicesObjectNameNormalizer.cs
+++ b/source/Server/DirectoryServices/IDirectoryServicesObjectNameNormalizer.cs
@@ -2,8 +2,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 {
     interface IDirectoryServicesObjectNameNormalizer
     {
-        void NormalizeName(string name, out string namePart, out string domainPart);
+        DomainUser NormalizeName(string name);
 
-        string ValidatedUserPrincipalName(string userPrincipalName, string fallbackUsername, string fallbackDomain);
+        string ValidatedUserPrincipalName(string? userPrincipalName, string? fallbackUsername, string? fallbackDomain);
     }
 }

--- a/source/Server/DirectoryServices/UserLookup.cs
+++ b/source/Server/DirectoryServices/UserLookup.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.Configuration;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.Identities;
 using Octopus.Server.Extensibility.Authentication.Extensions;
+using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices
 {
@@ -27,10 +28,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.identityCreator = identityCreator;
         }
 
-        public ExternalUserLookupResult? Search(string searchTerm, CancellationToken cancellationToken)
+        public ResultFromExtension<ExternalUserLookupResult> Search(string searchTerm, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled())
-                return null;
+                return ResultFromExtension<ExternalUserLookupResult>.ExtensionDisabled();
 
             var domainUser = objectNameNormalizer.NormalizeName(searchTerm);
 
@@ -47,7 +48,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
                         u.DisplayName).ToResource())
                     .ToArray();
                 
-                return new ExternalUserLookupResult(DirectoryServicesAuthentication.ProviderName, identityResources);
+                return ResultFromExtension<ExternalUserLookupResult>.Success(new ExternalUserLookupResult(DirectoryServicesAuthentication.ProviderName, identityResources));
             }
         }
 

--- a/source/Server/DirectoryServices/UserLookup.cs
+++ b/source/Server/DirectoryServices/UserLookup.cs
@@ -30,7 +30,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
         public string IdentityProviderName => DirectoryServicesAuthentication.ProviderName;
 
-        public ResultFromExtension<ExternalUserLookupResult> Search(string searchTerm, CancellationToken cancellationToken)
+        public IResultFromExtension<ExternalUserLookupResult> Search(string searchTerm, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled())
                 return ResultFromExtension<ExternalUserLookupResult>.ExtensionDisabled();
@@ -49,7 +49,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
                     .Select(u => identityCreator.Create("", u.UserPrincipalName, ConvertSamAccountName(u, domainUser.Domain),
                         u.DisplayName).ToResource())
                     .ToArray();
-                
+
                 return ResultFromExtension<ExternalUserLookupResult>.Success(new ExternalUserLookupResult(identityResources));
             }
         }

--- a/source/Server/DirectoryServices/UserLookup.cs
+++ b/source/Server/DirectoryServices/UserLookup.cs
@@ -28,6 +28,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.identityCreator = identityCreator;
         }
 
+        public string IdentityProviderName => DirectoryServicesAuthentication.ProviderName;
+
         public ResultFromExtension<ExternalUserLookupResult> Search(string searchTerm, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled())
@@ -37,7 +39,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
             using (var context = contextProvider.GetContext(domainUser.Domain))
             {
-                if (cancellationToken.IsCancellationRequested) return null;
+                if (cancellationToken.IsCancellationRequested) return ResultFromExtension<ExternalUserLookupResult>.Failed("Cancellation requested.");
 
                 var identities = new List<Principal>(SearchBy(new UserPrincipal(context) { Name = "*" + domainUser.NormalizedName + "*" }));
                 identities.AddRange(SearchBy(new UserPrincipal(context) { UserPrincipalName = "*" + domainUser.NormalizedName + "*" }));
@@ -48,7 +50,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
                         u.DisplayName).ToResource())
                     .ToArray();
                 
-                return ResultFromExtension<ExternalUserLookupResult>.Success(new ExternalUserLookupResult(DirectoryServicesAuthentication.ProviderName, identityResources));
+                return ResultFromExtension<ExternalUserLookupResult>.Success(new ExternalUserLookupResult(identityResources));
             }
         }
 

--- a/source/Server/DirectoryServices/UserMatcher.cs
+++ b/source/Server/DirectoryServices/UserMatcher.cs
@@ -27,6 +27,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             this.identityCreator = identityCreator;
         }
 
+        public string IdentityProviderName => DirectoryServicesAuthentication.ProviderName;
+
         public Identity? Match(string name, CancellationToken cancellationToken)
         {
             if (!configurationStore.GetIsEnabled())

--- a/source/Server/DirectoryServices/UserValidationResult.cs
+++ b/source/Server/DirectoryServices/UserValidationResult.cs
@@ -4,7 +4,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 {
     class UserValidationResult
     {
-        public UserValidationResult(UserPrincipal userPrincipal, string domain)
+        public UserValidationResult(UserPrincipal userPrincipal, string? domain)
             :this(userPrincipal.UserPrincipalName,
                 $"{domain}\\{userPrincipal.SamAccountName}",
                 domain, 
@@ -13,7 +13,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         {
         }
 
-        public UserValidationResult(string userPrincipalName, string samAccountName, string domain, string displayName, string emailAddress)
+        public UserValidationResult(string userPrincipalName, string samAccountName, string? domain, string displayName, string emailAddress)
         {
             UserPrincipalName = userPrincipalName;
             SamAccountName = samAccountName.Contains("\\") ? samAccountName : $"{domain}\\{samAccountName}";
@@ -29,14 +29,14 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             ValidationMessage = validationMessage;
         }
 
-        public string UserPrincipalName { get; }
-        public string SamAccountName { get; }
-        public string Domain { get; }
+        public string? UserPrincipalName { get; }
+        public string? SamAccountName { get; }
+        public string? Domain { get; }
 
-        public string DisplayName { get; }
-        public string EmailAddress { get; }
+        public string? DisplayName { get; }
+        public string? EmailAddress { get; }
 
         public bool Success { get; }
-        public string ValidationMessage { get; }
+        public string? ValidationMessage { get; }
     }
 }

--- a/source/Server/DirectoryServicesAuthenticationProvider.cs
+++ b/source/Server/DirectoryServicesAuthenticationProvider.cs
@@ -46,7 +46,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices
             return authenticationProviderElement;
         }
 
-        public AuthenticationProviderThatSupportsGroups GetGroupLookupElement()
+        public AuthenticationProviderThatSupportsGroups? GetGroupLookupElement()
         {
             if (!configurationStore.GetAreSecurityGroupsEnabled())
                 return null;

--- a/source/Server/DirectoryServicesAuthenticationProvider.cs
+++ b/source/Server/DirectoryServicesAuthenticationProvider.cs
@@ -17,8 +17,6 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices
         IContributesCSS,
         IContributesJavascript
     {
-        public const string ProviderName = "Active Directory";
-
         readonly IDirectoryServicesConfigurationStore configurationStore;
 
         public DirectoryServicesAuthenticationProvider(IDirectoryServicesConfigurationStore configurationStore)
@@ -82,7 +80,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices
         {
             return new IdentityMetadataResource
             {
-                IdentityProviderName = ProviderName,
+                IdentityProviderName = IdentityProviderName,
                 ClaimDescriptors = new []
                 {
                     new ClaimDescriptor { Type = IdentityCreator.UpnClaimType, Label = "User principal name", IsIdentifyingClaim = true, Description = "UPN identifier."}, 

--- a/source/Server/IntegratedAuthentication/IIntegratedChallengeCoordinator.cs
+++ b/source/Server/IntegratedAuthentication/IIntegratedChallengeCoordinator.cs
@@ -5,6 +5,6 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
 {
     interface IIntegratedChallengeCoordinator
     {
-        IntegratedChallengeTrackerStatus SetupResponseIfChallengeHasNotSucceededYet(HttpContext context, LoginState state);
+        IntegratedChallengeTrackerStatus SetupResponseIfChallengeHasNotSucceededYet(HttpContext context, LoginState? state);
     }
 }

--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
@@ -130,10 +130,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
                 var userResult = supportsAutoUserCreationFromPrincipals.GetOrCreateUser(principal, cts.Token);
 
                 // If we couldn't create the user account we also can't authenticate this request
-                if (userResult == null || !userResult.Succeeded) return null;
+                if (userResult == null || userResult.WasFailure) return null;
 
                 // Otherwise we should be good to go!
-                var user = userStore.GetByIdentificationToken(userResult.User.IdentificationToken);
+                var user = userStore.GetByIdentificationToken(userResult.Value.IdentificationToken);
 
                 return Result<IUser>.Success(user);
             }

--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
@@ -11,6 +11,7 @@ using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices;
 using Octopus.Server.Extensibility.Authentication.HostServices;
 using Octopus.Server.Extensibility.Authentication.Resources;
+using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.IntegratedAuthentication
 {
@@ -132,10 +133,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
                 var userResult = supportsAutoUserCreationFromPrincipals.GetOrCreateUser(principal, cts.Token);
 
                 // If we couldn't create the user account we also can't authenticate this request
-                if (userResult == null || userResult.WasFailure || userResult.Value == null) return null;
+                if (userResult is FailureResult) return null;
 
                 // Otherwise we should be good to go!
-                var user = userStore.GetByIdentificationToken(userResult.Value.IdentificationToken);
+                var user = userStore.GetByIdentificationToken(((ResultFromExtension<IUser>)userResult).Value.IdentificationToken);
 
                 return Result<IUser>.Success(user);
             }

--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
@@ -4,9 +4,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
+using Octopus.Data;
+using Octopus.Data.Model.User;
 using Octopus.Data.Storage.User;
 using Octopus.Diagnostics;
-using Octopus.Server.Extensibility.Authentication.DirectoryServices.Configuration;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices;
 using Octopus.Server.Extensibility.Authentication.HostServices;
 using Octopus.Server.Extensibility.Authentication.Resources;
@@ -50,8 +51,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
             // Challenge has succeeded!!
 
             var result = TryAuthenticateRequest(context);
+            if (result == null)
+                return Task.CompletedTask;
             
-            var principal = result.User;
+            var principal = result.Value;
 
             // Build the auth cookies to send back with the response
             var authCookies = tokenIssuer.CreateAuthCookies(principal.IdentificationToken, SessionExpiry.TwentyDays, context.Request.IsHttps, state?.UsingSecureConnection);
@@ -88,13 +91,13 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
             return Task.CompletedTask;
         }
 
-        LoginState GetLoginState(HttpContext context)
+        LoginState? GetLoginState(HttpContext context)
         {
             // Decode the state object sent from the client (if there was one) so we can use those hints to build the most appropriate response
             // If the state can't be interpreted, we will fall back to a safe-by-default behaviour, however:
             //   1. Deep-links will not work because we don't know where the anonymous request originally wanted to go
             //   2. Cookies may not have the Secure flag set properly when SSL Offloading is in play
-            LoginState state = null;
+            LoginState? state = null;
             if (context.Request.Query.TryGetValue("state", out var stateString))
             {
                 try
@@ -110,7 +113,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
             return state;
         }
 
-        OctopusAuthenticationResult TryAuthenticateRequest(HttpContext context)
+        /// <returns>Null if the user is currently unknown.</returns>
+        Result<IUser>? TryAuthenticateRequest(HttpContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             if (context.Request == null) throw new ArgumentNullException($"{nameof(context)}.{nameof(context.Request)}");
@@ -118,7 +122,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
             // If there is no "RequestPrincipal" in the Context.Items it's not our job to authenticate this request
             var principal = context.User;
             if (string.IsNullOrWhiteSpace(principal.Identity.Name))
-                return OctopusAuthenticationResult.Anonymous;
+                return null;
 
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(context.RequestAborted, new CancellationTokenSource(TimeSpan.FromMinutes(1)).Token))
             {
@@ -126,16 +130,13 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
                 var userResult = supportsAutoUserCreationFromPrincipals.GetOrCreateUser(principal, cts.Token);
 
                 // If we couldn't create the user account we also can't authenticate this request
-                if (userResult == null || !userResult.Succeeded) return OctopusAuthenticationResult.Anonymous;
+                if (userResult == null || !userResult.Succeeded) return null;
 
                 // Otherwise we should be good to go!
                 var user = userStore.GetByIdentificationToken(userResult.User.IdentificationToken);
 
-                return user == null
-                    ? OctopusAuthenticationResult.Anonymous
-                    : OctopusAuthenticationResult.Authenticated(user);
+                return Result<IUser>.Success(user);
             }
         }
-
     }
 }

--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationHost.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationHost.cs
@@ -40,7 +40,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
         readonly IWebPortalConfigurationStore configuration;
         readonly IDirectoryServicesConfigurationStore configurationStore;
         readonly IIntegratedAuthenticationHandler handler;
-        IWebHost host;
+        IWebHost? host;
 
         public IntegratedAuthenticationHost(ILog log,
             IWebPortalConfigurationStore configuration,

--- a/source/Server/IntegratedAuthentication/IntegratedChallengeCoordinator.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedChallengeCoordinator.cs
@@ -23,7 +23,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
             this.clock = clock;
         }
         
-        public IntegratedChallengeTrackerStatus SetupResponseIfChallengeHasNotSucceededYet(HttpContext context, LoginState state)
+        public IntegratedChallengeTrackerStatus SetupResponseIfChallengeHasNotSucceededYet(HttpContext context, LoginState? state)
         {
             // Based on https://github.com/dotnet/runtime/blob/cf63e732fc6fb57c0ea97c1b4ca965acce46343a/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Windows.cs#L52
             // we're being a bit cautious about using IsAuthenticated
@@ -41,7 +41,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
                 // wrong with the challenge. Most likely to us using HTTPS.sys https://docs.microsoft.com/en-us/aspnet/core/security/authentication/windowsauth?view=aspnetcore-3.1&tabs=visual-studio#httpsys
                 // User mode authentication isn't supported with Kerberos and HTTP.sys. The machine account must be used to decrypt the Kerberos token/ticket that's obtained from Active Directory
                 // SPN KB: https://support.microsoft.com/en-us/help/929650/how-to-use-spns-when-you-configure-web-applications-that-are-hosted-on
-                var stateRedirectAfterLoginTo = state.RedirectAfterLoginTo;
+                var stateRedirectAfterLoginTo = state?.RedirectAfterLoginTo;
 
                 // this matches an error structure that the portal currently uses. It is not something the server
                 // currently knows directly about. We may make it a first-class error object at some point to help consistency.
@@ -61,7 +61,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
                     new CookieOptions
                     {
                         MaxAge = TimeSpan.FromSeconds(15),
-                        Secure = state.UsingSecureConnection
+                        Secure = state?.UsingSecureConnection ?? false
                     });
                 
                 // we pass back to the original link here (e.g. the deep link that originally triggered the sign in)

--- a/source/Server/IntegratedAuthentication/OctopusAuthenticationResult.cs
+++ b/source/Server/IntegratedAuthentication/OctopusAuthenticationResult.cs
@@ -1,31 +1,19 @@
-using Microsoft.AspNetCore.Http;
 using Octopus.Data.Model.User;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.IntegratedAuthentication
 {
     class OctopusAuthenticationResult
     {
-        OctopusAuthenticationResult(IUser user, HttpResponse rejectionResponse)
+        OctopusAuthenticationResult(IUser user)
         {
             User = user;
-            RejectionResponse = rejectionResponse;
         }
 
         public IUser User { get; }
-        public HttpResponse RejectionResponse { get; }
             
-        public bool IsAnonymous => User == null && RejectionResponse == null;
-
-        public static readonly OctopusAuthenticationResult Anonymous = new OctopusAuthenticationResult(null, null);
-
         public static OctopusAuthenticationResult Authenticated(IUser user)
         {
-            return new OctopusAuthenticationResult(user, null);
-        }
-
-        public static OctopusAuthenticationResult Rejected(HttpResponse rejectionResponse)
-        {
-            return new OctopusAuthenticationResult(null, rejectionResponse);
+            return new OctopusAuthenticationResult(user);
         }
     }
 }

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.DirectoryServices</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.DirectoryServices</AssemblyName>
     <Description>Implements the DirectoryServices authentication provider.</Description>
@@ -9,8 +9,9 @@
     <Authors>Octopus Deploy</Authors>
     <PackageId>Octopus.Server.Extensibility.Authentication.DirectoryServices</PackageId>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/OctopusDeploy/DirectoryServicesAuthenticationProvider/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/DirectoryServicesAuthenticationProvider</PackageProjectUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
@@ -20,10 +21,10 @@
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
-    <PackageReference Include="Octopus.Data" Version="5.0.0" />
+    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0004" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.1.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0005" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0005" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -12,6 +12,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/OctopusDeploy/DirectoryServicesAuthenticationProvider</PackageProjectUrl>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
@@ -20,11 +21,11 @@
     <PackageReference Include="Octopus.Time" Version="1.1.6" />
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
-    <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
-    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0013" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.4-enh-nullable0014" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0013" />
+    <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
+    <PackageReference Include="Octopus.Data" Version="5.1.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.1" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -21,10 +21,10 @@
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
-    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
+    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0013" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0007" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0010" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.4-enh-nullable0014" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0013" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -22,9 +22,9 @@
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0001" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1-ci0001" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -22,10 +22,9 @@
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
-    <PackageReference Include="Octopus.Data" Version="5.1.0" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.1" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0001" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="10.0.1-ci0001" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0007" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0007" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0010" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -21,10 +21,10 @@
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
-    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0004" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0005" />
-    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0005" />
+    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0007" />
+    <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.3.1-enh-nullable0007" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />

--- a/source/Server/Web/ListSecurityGroupsAction.cs
+++ b/source/Server/Web/ListSecurityGroupsAction.cs
@@ -32,7 +32,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Web
                 if (result != null)
                     context.Response.AsOctopusJson(result);
                 else
-                    context.Response.BadRequest($"The {DirectoryServicesAuthenticationProvider.ProviderName} is currently disable");
+                    context.Response.BadRequest($"The {DirectoryServicesAuthentication.ProviderName} is currently disable");
             }
 
             return Task.FromResult(0);

--- a/source/Server/Web/ListSecurityGroupsAction.cs
+++ b/source/Server/Web/ListSecurityGroupsAction.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices;
-using Octopus.Server.Extensibility.Authentication.HostServices;
 using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Web
@@ -29,15 +28,14 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Web
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
             {
-                context.Response.AsOctopusJson(SearchByName(name, cts.Token));
+                var result = externalSecurityGroupLocator.Search(name, cts.Token);
+                if (result != null)
+                    context.Response.AsOctopusJson(result);
+                else
+                    context.Response.BadRequest($"The {DirectoryServicesAuthenticationProvider.ProviderName} is currently disable");
             }
 
             return Task.FromResult(0);
-        }
-
-        ExternalSecurityGroup[] SearchByName(string name, CancellationToken cancellationToken)
-        {
-            return externalSecurityGroupLocator.Search(name, cancellationToken).Groups;
         }
     }
 }

--- a/source/Server/Web/ListSecurityGroupsAction.cs
+++ b/source/Server/Web/ListSecurityGroupsAction.cs
@@ -23,7 +23,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Web
             if (string.IsNullOrWhiteSpace(name))
             {
                 context.Response.BadRequest("Please provide the name of a group to search by, or a team");
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
@@ -32,10 +32,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Web
                 if (result != null)
                     context.Response.AsOctopusJson(result);
                 else
-                    context.Response.BadRequest($"The {DirectoryServicesAuthentication.ProviderName} is currently disable");
+                    context.Response.BadRequest($"The {DirectoryServicesAuthentication.ProviderName} is currently disabled");
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }

--- a/source/Server/Web/UserLookupAction.cs
+++ b/source/Server/Web/UserLookupAction.cs
@@ -28,7 +28,11 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Web
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
             {
-                context.Response.AsOctopusJson(userSearch.Search(name, cts.Token));
+                var externalUserLookupResult = userSearch.Search(name, cts.Token);
+                if (externalUserLookupResult != null)
+                    context.Response.AsOctopusJson(externalUserLookupResult);
+                else
+                    context.Response.BadRequest($"The {DirectoryServicesAuthenticationProvider.ProviderName} is currently disable");
             }
 
             return Task.FromResult(0);

--- a/source/Server/Web/UserLookupAction.cs
+++ b/source/Server/Web/UserLookupAction.cs
@@ -32,7 +32,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Web
                 if (externalUserLookupResult != null)
                     context.Response.AsOctopusJson(externalUserLookupResult);
                 else
-                    context.Response.BadRequest($"The {DirectoryServicesAuthenticationProvider.ProviderName} is currently disable");
+                    context.Response.BadRequest($"The {DirectoryServicesAuthentication.ProviderName} is currently disable");
             }
 
             return Task.FromResult(0);

--- a/source/Server/Web/UserLookupAction.cs
+++ b/source/Server/Web/UserLookupAction.cs
@@ -7,12 +7,11 @@ using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Web
 {
-    class UserLookupAction : IAsyncApiAction
+    internal class UserLookupAction : IAsyncApiAction
     {
         readonly ICanSearchActiveDirectoryUsers userSearch;
 
-        public UserLookupAction(
-            ICanSearchActiveDirectoryUsers userSearch)
+        public UserLookupAction(ICanSearchActiveDirectoryUsers userSearch)
         {
             this.userSearch = userSearch;
         }
@@ -23,7 +22,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Web
             if (string.IsNullOrWhiteSpace(name))
             {
                 context.Response.BadRequest("Please provide the name of a user to search for");
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
@@ -32,10 +31,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Web
                 if (externalUserLookupResult != null)
                     context.Response.AsOctopusJson(externalUserLookupResult);
                 else
-                    context.Response.BadRequest($"The {DirectoryServicesAuthentication.ProviderName} is currently disable");
+                    context.Response.BadRequest($"The {DirectoryServicesAuthentication.ProviderName} is currently disabled");
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Changing the method return types to align with the new nullable patterns we've set up in ServerExtensibility and AuthenticationExtensibility.

Depends on:
OctopusDeploy/AuthenticationExtensibility#15