### PR TITLE
Reintroduce CORS and Cookie domain for AD endpoint - 7.x.x (Server 2020.3)

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -21,7 +21,7 @@ var publishDir = "./publish";
 var localPackagesDir = "../LocalPackages";
 var artifactsDir = "./artifacts";
 var assetDir = "./BuildAssets";
-var netstd = "/bin/Release/netstandard2.0/";
+var netstd = "/bin/Release/netstandard2.1/";
 
 var gitVersionInfo = GitVersion(new GitVersionSettings {
     OutputType = GitVersionOutput.Json

--- a/source/DirectoryServices.Tests/DirectoryServices.Tests.csproj
+++ b/source/DirectoryServices.Tests/DirectoryServices.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Assent" Version="1.3.0" />

--- a/source/DirectoryServices.Tests/OnlyExposeWhatIsNecessary.ServerExtensionsShouldMinimiseWhatIsExposed.approved.txt
+++ b/source/DirectoryServices.Tests/OnlyExposeWhatIsNecessary.ServerExtensionsShouldMinimiseWhatIsExposed.approved.txt
@@ -1,1 +1,3 @@
 Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServicesExtension
+Octopus.Server.Extensibility.Authentication.DirectoryServices.IntegratedAuthentication.ApiConstants
+Octopus.Server.Extensibility.Authentication.DirectoryServices.IntegratedAuthentication.DomainCookieOptions

--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
@@ -63,7 +63,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
             context.Response.Headers.Add("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE, OPTIONS");
             context.Response.Headers.Add("Access-Control-Allow-Credentials", "true");
             context.Response.Headers.Add("Access-Control-Expose-Headers", $"{ApiConstants.OctopusDataVersionHeaderName}, {ApiConstants.OctopusAuthorizationHashHeaderName}, {ApiConstants.OctopusNode}");
-            context.Response.Headers.Add("Access-Control-Expose-Headers",$"cache-control, content-type, x-http-method-override, {ApiConstants.OctopusDataVersionHeaderName}, {ApiConstants.OctopusAuthorizationHashHeaderName}, {ApiConstants.ApiKeyHttpHeaderName}, {ApiConstants.AntiforgeryTokenHttpHeaderName}, {ApiConstants.OctopusUserAgentHeaderName}" );
+            context.Response.Headers.Add("Access-Control-Allow-Headers",$"cache-control, content-type, x-http-method-override, {ApiConstants.OctopusDataVersionHeaderName}, {ApiConstants.OctopusAuthorizationHashHeaderName}, {ApiConstants.ApiKeyHttpHeaderName}, {ApiConstants.AntiforgeryTokenHttpHeaderName}, {ApiConstants.OctopusUserAgentHeaderName}" );
             context.Request.Headers.TryGetValue("Access-Control-Request-Method", out var accessControlRequestMethod);
             context.Response.Headers.Add("Allow", accessControlRequestMethod.Any() ? accessControlRequestMethod.FirstOrDefault() ?? "GET" : "GET");
         }

--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
@@ -6,16 +6,34 @@ using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using Octopus.Data.Storage.User;
 using Octopus.Diagnostics;
-using Octopus.Server.Extensibility.Authentication.DirectoryServices.Configuration;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices;
 using Octopus.Server.Extensibility.Authentication.HostServices;
 using Octopus.Server.Extensibility.Authentication.Resources;
+using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
+using Octopus.Server.Extensibility.HostServices.Web;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.IntegratedAuthentication
 {
+    public static class ApiConstants
+    {
+        public const string OctopusNode = "Octopus-Node";
+        public const string ApiKeyHttpHeaderName = "X-Octopus-ApiKey";
+        public const string AntiforgeryTokenHttpHeaderName = "X-Octopus-Csrf-Token";
+        public const string OctopusUserAgentHeaderName = "X-Octopus-User-Agent";
+        public const string OctopusDataVersionHeaderName = "X-Octopus-Data-Version";
+        public const string OctopusAuthorizationHashHeaderName = "X-Octopus-Authorization-Hash";
+    }
+
+    public enum DomainCookieOptions
+    {
+        CustomDomain = 0,
+        OriginDomain = 1,
+    }
+    
     class IntegratedAuthenticationHandler : IIntegratedAuthenticationHandler
     {
         readonly ILog log;
+        readonly IWebPortalConfigurationStore configuration;
         readonly IAuthCookieCreator tokenIssuer;
         readonly IAuthenticationConfigurationStore authenticationConfigurationStore;
         readonly DirectoryServicesUserCreationFromPrincipal supportsAutoUserCreationFromPrincipals;
@@ -23,6 +41,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
         readonly IIntegratedChallengeCoordinator integratedChallengeCoordinator;
 
         public IntegratedAuthenticationHandler(ILog log,
+            IWebPortalConfigurationStore configuration,
             IAuthCookieCreator tokenIssuer,
             IAuthenticationConfigurationStore authenticationConfigurationStore, 
             DirectoryServicesUserCreationFromPrincipal supportsAutoUserCreationFromPrincipals,
@@ -30,6 +49,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
             IIntegratedChallengeCoordinator integratedChallengeCoordinator)
         {
             this.log = log;
+            this.configuration = configuration;
             this.tokenIssuer = tokenIssuer;
             this.authenticationConfigurationStore = authenticationConfigurationStore;
             this.supportsAutoUserCreationFromPrincipals = supportsAutoUserCreationFromPrincipals;
@@ -37,10 +57,21 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
             this.integratedChallengeCoordinator = integratedChallengeCoordinator;
         }
 
+        void AddCorsHeaders(HttpContext context)
+        {
+            context.Response.Headers.Add("Access-Control-Allow-Origin", configuration.GetCorsWhitelist());
+            context.Response.Headers.Add("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE, OPTIONS");
+            context.Response.Headers.Add("Access-Control-Allow-Credentials", "true");
+            context.Response.Headers.Add("Access-Control-Expose-Headers", $"{ApiConstants.OctopusDataVersionHeaderName}, {ApiConstants.OctopusAuthorizationHashHeaderName}, {ApiConstants.OctopusNode}");
+            context.Response.Headers.Add("Access-Control-Expose-Headers",$"cache-control, content-type, x-http-method-override, {ApiConstants.OctopusDataVersionHeaderName}, {ApiConstants.OctopusAuthorizationHashHeaderName}, {ApiConstants.ApiKeyHttpHeaderName}, {ApiConstants.AntiforgeryTokenHttpHeaderName}, {ApiConstants.OctopusUserAgentHeaderName}" );
+            context.Request.Headers.TryGetValue("Access-Control-Request-Method", out var accessControlRequestMethod);
+            context.Response.Headers.Add("Allow", accessControlRequestMethod.Any() ? accessControlRequestMethod.FirstOrDefault() ?? "GET" : "GET");
+        }
+
         public Task HandleRequest(HttpContext context)
         {
             var state = GetLoginState(context);
-
+            AddCorsHeaders(context);
             if (integratedChallengeCoordinator.SetupResponseIfChallengeHasNotSucceededYet(context, state) != IntegratedChallengeTrackerStatus.ChallengeSucceeded)
             {
                 // the coordinator will configure the Response object in the correct way for incomplete challenges
@@ -65,9 +96,11 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
                 {
                     // This is a safe redirect, let's go!
                     context.Response.Redirect(redirectAfterLoginTo);
+                    var isLocalhost = String.Compare(context.Request.Host.Value, "localhost", StringComparison.OrdinalIgnoreCase) == 0;
                     foreach (var cookie in authCookies)
                     {
-                        context.Response.Cookies.Append(cookie.Name, cookie.Value);
+                        //If the current host happens to be localhost, then we don't want to set the cookie domain as this will result in being unable to log in using AD credentials when using localhost
+                        context.Response.Cookies.Append(cookie.Name, cookie.Value, ConvertOctoCookieToCookieOptions(cookie, isLocalhost ? DomainCookieOptions.OriginDomain : DomainCookieOptions.CustomDomain));
                     }
                     return Task.CompletedTask;
                 }
@@ -82,10 +115,25 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
             context.Response.Redirect(context.Request.PathBase.Value ?? "/");
             foreach (var cookie in authCookies)
             {
-                context.Response.Cookies.Append(cookie.Name, cookie.Value);
+                context.Response.Cookies.Append(cookie.Name, cookie.Value, ConvertOctoCookieToCookieOptions(cookie, DomainCookieOptions.CustomDomain));
             }
             
             return Task.CompletedTask;
+        }
+        
+        CookieOptions ConvertOctoCookieToCookieOptions(OctoCookie cookie, DomainCookieOptions options)
+        {
+            var result = new CookieOptions
+            {
+                Domain = options == DomainCookieOptions.CustomDomain ? cookie.Domain: null,
+                Expires = cookie.Expires, 
+                Path = cookie.Path, 
+                HttpOnly = cookie.HttpOnly,
+                Secure = cookie.Secure,
+                MaxAge = cookie.MaxAge,
+            };
+            
+            return result;
         }
 
         LoginState GetLoginState(HttpContext context)

--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationHost.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationHost.cs
@@ -87,8 +87,9 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
                 }
             });
             
-             builder.Configure(app =>
+            builder.Configure(app =>
              {
+                 //This short-circuits the .net core pipeline and other middleware, so don't expect any favours from other middleware. 
                  app.Use((context, func) =>
                  {
                      if (!configurationStore.GetIsEnabled())

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
     <PackageReference Include="Octopus.Data" Version="5.0.4" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.4-beta0001" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.4" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.Authentication.DirectoryServices</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication.DirectoryServices</AssemblyName>
     <Description>Implements the DirectoryServices authentication provider.</Description>
@@ -20,9 +20,9 @@
     <PackageReference Include="System.DirectoryServices" Version="4.5.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
-    <PackageReference Include="Octopus.Data" Version="5.0.0" />
+    <PackageReference Include="Octopus.Data" Version="5.0.4" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.4-beta0001" />
     <PackageReference Include="Octopus.Server.Extensibility.Authentication" Version="9.1.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This includes the associated changes needed to reintroduce CORS related headers and to include the associated cookie domain which was causing some grief for customers that had custom UI and using integrated auth. These changes are meant for version 7.x.x which coincides with Octopus version `2020.3`. Generally these libraries are pretty stable and backwards compatible for the majority part, however we have been introducing a number of breaking changes due to null reference checks which complicated this work.