### PR TITLE
Align how we set CORS allow origin header with server

### DIFF
--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationHandler.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
+using Octopus.CoreUtilities;
 using Octopus.Data.Storage.User;
 using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.DirectoryServices;
@@ -56,22 +58,49 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
             this.userStore = userStore;
             this.integratedChallengeCoordinator = integratedChallengeCoordinator;
         }
+        
+        static Maybe<string> GetCorsOrigin(IEnumerable<string> originHeaders, string whitelist)
+        {
+            if (string.IsNullOrWhiteSpace(whitelist))
+                return Maybe<string>.None;
+
+            IEnumerable<string> headersArray = originHeaders == null ? new string[0] : originHeaders.ToArray();
+
+            if (whitelist.Equals("*"))
+            {
+                var firstHeader = headersArray.FirstOrDefault();
+                return Maybe<string>.Some(firstHeader ?? "*");
+            }
+
+            var originHeader = headersArray.FirstOrDefault() ?? "";
+            var allowedDomains = whitelist.Split(',');
+            return allowedDomains.Contains(originHeader, StringComparer.OrdinalIgnoreCase) ? Maybe<string>.Some(originHeader) : Maybe<string>.None;
+        }
 
         void AddCorsHeaders(HttpContext context)
         {
-            context.Response.Headers.Add("Access-Control-Allow-Origin", configuration.GetCorsWhitelist());
+            context.Request.Headers.TryGetValue("Origin", out var originHeaders);
+            var maybeAllowOrigin = GetCorsOrigin(originHeaders, configuration.GetCorsWhitelist());
+            if (!maybeAllowOrigin.Some()) return;
+            
+            context.Response.Headers.Add("Access-Control-Allow-Origin", maybeAllowOrigin.Value);
             context.Response.Headers.Add("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE, OPTIONS");
             context.Response.Headers.Add("Access-Control-Allow-Credentials", "true");
-            context.Response.Headers.Add("Access-Control-Expose-Headers", $"{ApiConstants.OctopusDataVersionHeaderName}, {ApiConstants.OctopusAuthorizationHashHeaderName}, {ApiConstants.OctopusNode}");
-            context.Response.Headers.Add("Access-Control-Allow-Headers",$"cache-control, content-type, x-http-method-override, {ApiConstants.OctopusDataVersionHeaderName}, {ApiConstants.OctopusAuthorizationHashHeaderName}, {ApiConstants.ApiKeyHttpHeaderName}, {ApiConstants.AntiforgeryTokenHttpHeaderName}, {ApiConstants.OctopusUserAgentHeaderName}" );
-            context.Request.Headers.TryGetValue("Access-Control-Request-Method", out var accessControlRequestMethod);
-            context.Response.Headers.Add("Allow", accessControlRequestMethod.Any() ? accessControlRequestMethod.FirstOrDefault() ?? "GET" : "GET");
+            context.Response.Headers.Add("Access-Control-Expose-Headers",
+                $"{ApiConstants.OctopusDataVersionHeaderName}, {ApiConstants.OctopusAuthorizationHashHeaderName}, {ApiConstants.OctopusNode}");
+            context.Response.Headers.Add("Access-Control-Allow-Headers",
+                $"cache-control, content-type, x-http-method-override, {ApiConstants.OctopusDataVersionHeaderName}, {ApiConstants.OctopusAuthorizationHashHeaderName}, {ApiConstants.ApiKeyHttpHeaderName}, {ApiConstants.AntiforgeryTokenHttpHeaderName}, {ApiConstants.OctopusUserAgentHeaderName}");
+            context.Request.Headers.TryGetValue("Access-Control-Request-Method",
+                out var accessControlRequestMethod);
+            context.Response.Headers.Add("Allow",
+                accessControlRequestMethod.Any() ? accessControlRequestMethod.FirstOrDefault() ?? "GET" : "GET");
         }
 
         public Task HandleRequest(HttpContext context)
         {
-            var state = GetLoginState(context);
             AddCorsHeaders(context);
+            var state = GetLoginState(context);
+            
             if (integratedChallengeCoordinator.SetupResponseIfChallengeHasNotSucceededYet(context, state) != IntegratedChallengeTrackerStatus.ChallengeSucceeded)
             {
                 // the coordinator will configure the Response object in the correct way for incomplete challenges


### PR DESCRIPTION
This PR pulls part of the behavior we have around the CORS origin header from server into the integrated challenge endpoint for server `2020.3.x`. 

We previously included part of this functionality and exposed the CORS headers, and setting the appropriate cookie domain, however adapting the `Access-Control-Allow-Origin` based on the `Origin` header when we specify a wildcard (`*`) CORS whitelist was unfortunately omitted.