### PR TITLE
Run integrated host for HTTP.sys even when plugin is off

### DIFF
--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationHost.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationHost.cs
@@ -55,11 +55,6 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
 
         public Task StartAsync()
         {
-            if (!configurationStore.GetIsEnabled())
-            {
-                return Task.CompletedTask;
-            }
-
             if (configuration.GetWebServer() != WebServer.HttpSys)
             {
                 // This HTTP.sys based integrated authentication endpoint will only work when the server is also


### PR DESCRIPTION
I was over-eager turning of the integrated authentication endpoint. This was left on deliberatly so that changes could be made to the plugin configuration without needing to restart the Octopus server (to get this endpoint fired up again).