### PR TITLE
Upgrade build to latest Nuke + OctoVersion and add tags on release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,19 @@ jobs:
         env:
           OCTOVERSION_CurrentBranch: ${{ github.ref }}
 
+      - name: Tag release (when not pre-release) 🏷️
+        if: ${{ !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.build.outputs.octoversion_fullsemver }}",
+              sha: context.sha
+            })
+
       - name: Install Octopus CLI 🐙
         uses: OctopusDeploy/install-octopus-cli-action@v1.1.1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
         id: build
         shell: pwsh
         run: ./build.ps1 \
-        --OctoVersionBranch ${{ github.head_ref || github.ref }} \
-        --OctoVersionPatch ${{ github.run_number }}
+          --OctoVersionBranch ${{ github.head_ref || github.ref }} \
+          --OctoVersionPatch ${{ github.run_number }}
 
       - name: Tag release (when not pre-release) 🏷️
         if: ${{ !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Nuke Build 🏗
         id: build
         shell: pwsh
-        run: ./build.ps1 --verbosity verbose
-        env:
-          OCTOVERSION_CurrentBranch: ${{ github.ref }}
+        run: ./build.ps1 \
+        --OctoVersionBranch ${{ github.head_ref || github.ref }} \
+        --OctoVersionPatch ${{ github.run_number }}
 
       - name: Tag release (when not pre-release) 🏷️
         if: ${{ !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}
@@ -43,14 +43,27 @@ jobs:
             })
 
       - name: Install Octopus CLI 🐙
-        uses: OctopusDeploy/install-octopus-cli-action@v1.1.1
+        uses: OctopusDeploy/install-octopus-cli-action@v1.1.7
         with:
           version: latest
       
       - name: Push to Octopus 🐙
-        uses: OctopusDeploy/push-package-action@v1.0.1
+        uses: OctopusDeploy/push-package-action@v1.1.1
         with:
           server: https://deploy.octopus.app
           space: Integrations
           api_key: ${{ secrets.DEPLOY_API_KEY }}
-          packages: ${{ steps.build.outputs.packages_to_push }}
+          packages: |
+            ./artifacts/Octopus.Client.Extensibility.Authentication.DirectoryServices.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg
+            ./artifacts/Octopus.Server.Extensibility.Authentication.DirectoryServices.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg
+
+      - name: Create Release in Octopus 🐙
+        uses: OctopusDeploy/create-release-action@v1.1.1
+        with:
+          server: https://deploy.octopus.app
+          space: Integrations
+          api_key: ${{ secrets.DEPLOY_API_KEY }}
+          project: "DirectoryServicesAuthenticationProvider"
+          packages: |
+            Octopus.Client.Extensibility.Authentication.DirectoryServices:${{ steps.build.outputs.octoversion_fullsemver }}
+            Octopus.Server.Extensibility.Authentication.DirectoryServices:${{ steps.build.outputs.octoversion_fullsemver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,7 @@ jobs:
       - name: Nuke Build 🏗
         id: build
         shell: pwsh
-        run: ./build.ps1 \
-          --OctoVersionBranch ${{ github.head_ref || github.ref }} \
-          --OctoVersionPatch ${{ github.run_number }}
+        run: ./build.ps1 --OctoVersionBranch ${{ github.head_ref || github.ref }} --OctoVersionPatch ${{ github.run_number }}
 
       - name: Tag release (when not pre-release) 🏷️
         if: ${{ !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -35,6 +35,24 @@
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
         },
+        "OctoVersionAutoDetectBranch": {
+          "type": "boolean"
+        },
+        "OctoVersionBranch": {
+          "type": "string"
+        },
+        "OctoVersionFullSemVer": {
+          "type": "integer"
+        },
+        "OctoVersionMajor": {
+          "type": "integer"
+        },
+        "OctoVersionMinor": {
+          "type": "integer"
+        },
+        "OctoVersionPatch": {
+          "type": "integer"
+        },
         "Plan": {
           "type": "boolean",
           "description": "Shows the execution plan (HTML)"
@@ -56,12 +74,10 @@
           "items": {
             "type": "string",
             "enum": [
-              "CalculateVersion",
               "Clean",
               "Compile",
               "CopyToLocalPackages",
               "Default",
-              "OutputPackagesToPush",
               "Pack",
               "Restore",
               "Test"
@@ -78,12 +94,10 @@
           "items": {
             "type": "string",
             "enum": [
-              "CalculateVersion",
               "Clean",
               "Compile",
               "CopyToLocalPackages",
               "Default",
-              "OutputPackagesToPush",
               "Pack",
               "Restore",
               "Test"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,15 +1,12 @@
-using System.Linq;
 using Nuke.Common;
-using Nuke.Common.CI;
 using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.OctoVersion;
 using Nuke.Common.Utilities.Collections;
-using OctoVersion.Core;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
-using Nuke.OctoVersion;
 
 [CheckBuildProjectConfigurations]
 [UnsetVisualStudioEnvironmentVariables]
@@ -19,7 +16,22 @@ class Build : NukeBuild
 
     [Solution] readonly Solution Solution;
 
-    [NukeOctoVersion] readonly OctoVersionInfo OctoVersionInfo;
+    [Parameter] readonly bool? OctoVersionAutoDetectBranch = IsLocalBuild;
+    [Parameter] readonly string OctoVersionBranch;
+    [Parameter] readonly int? OctoVersionFullSemVer;
+    [Parameter] readonly int? OctoVersionMajor;
+    [Parameter] readonly int? OctoVersionMinor;
+    [Parameter] readonly int? OctoVersionPatch;
+
+    [Required]
+    [OctoVersion(
+        AutoDetectBranchParameter = nameof(OctoVersionAutoDetectBranch),
+        BranchParameter = nameof(OctoVersionBranch),
+        FullSemVerParameter = nameof(OctoVersionFullSemVer),
+        MajorParameter = nameof(OctoVersionMajor),
+        MinorParameter = nameof(OctoVersionMinor),
+        PatchParameter = nameof(OctoVersionPatch))]
+    readonly OctoVersionInfo OctoVersionInfo;
 
     static AbsolutePath SourceDirectory => RootDirectory / "source";
     static AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
@@ -33,12 +45,6 @@ class Build : NukeBuild
             SourceDirectory.GlobDirectories("**/bin", "**/obj", "**/TestResults").ForEach(DeleteDirectory);
             EnsureCleanDirectory(ArtifactsDirectory);
             EnsureCleanDirectory(PublishDirectory);
-        });
-
-    Target CalculateVersion => _ => _
-        .Executes(() =>
-        {
-            //all the magic happens inside `[NukeOctoVersion]` above. we just need a target for TeamCity to call
         });
 
     Target Restore => _ => _
@@ -113,19 +119,8 @@ class Build : NukeBuild
                 .ForEach(package => CopyFileToDirectory(package, LocalPackagesDir));
         });
 
-    Target OutputPackagesToPush => _ => _
-        .DependsOn(Pack)
-        .Executes(() =>
-        {
-            var artifactPaths = ArtifactsDirectory.GlobFiles("*.nupkg")
-                .NotEmpty()
-                .Select(p => p.ToString());
-
-            System.Console.WriteLine($"::set-output name=packages_to_push::{string.Join(',', artifactPaths)}");
-        });
-
     Target Default => _ => _
-        .DependsOn(OutputPackagesToPush);
+        .DependsOn(Pack);
 
     /// Support plugins are available for:
     /// - JetBrains ReSharper        https://nuke.build/resharper

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="5.4.0-mattr-octoversio0017" />
-    <PackageReference Include="OctoVersion.Tool" Version="0.2.685" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="5.4.0-mattr-octoversio0017" />
-    <PackageReference Include="Nuke.OctoVersion" Version="0.2.685" />
+    <PackageReference Include="OctoVersion.Tool" Version="0.2.685" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.2.685]" />
   </ItemGroup>
 
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.1.2" />
-    <PackageReference Include="Nuke.OctoVersion" Version="0.2.438" />
+    <PackageReference Include="Nuke.Common" Version="5.4.0-mattr-octoversio0017" />
+    <PackageReference Include="Nuke.OctoVersion" Version="0.2.685" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds tagging to releases of `DirectoryServicesAuthenticationProvider` and also tags them on release. Since the releases are no longer being tagged after moving to GH Actions it's hard to identify what the latest release actually is.

A lot of this was taken from https://github.com/OctopusDeploy/LdapAuthenticationProvider/pull/47