### PR TITLE
Add SwaggerOperation on integrated-challenge

### DIFF
--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationController.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.Configuration;
 using Octopus.Server.Extensibility.Web.Extensions;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.IntegratedAuthentication
 {
@@ -24,6 +25,10 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
 
         [AllowAnonymous]
         [HttpGet("integrated-challenge")]
+        [SwaggerOperation(
+            Summary = "Challenge the request against the integrated authentication scheme",
+            OperationId = "getIntegratedChallenge"
+        )]
         public async Task IntegratedChallenge()
         {
             if (!directoryServicesConfigurationStore.GetIsEnabled())

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Octopus.Server.Extensibility.Web" Version="0.0.24" />
     <PackageReference Include="Octopus.Time" Version="1.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.2.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />


### PR DESCRIPTION
Swagger is blowing up because the `integrated-challenge` endpoint doesn't have an OperationId https://github.com/OctopusDeploy/Issues/issues/7394