### PR TITLE
Downgrade Swashbuckle to 5.6.3 due to nuget issues

### DIFF
--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Octopus.Server.Extensibility.Web" Version="0.0.24" />
     <PackageReference Include="Octopus.Time" Version="1.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.2.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.6.3" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />


### PR DESCRIPTION
The credits build is breaking due to not being able to find `6.2.3`. This could probably be fixed but I think it would require updating our old `Nuget.Client` and some other stuff which is way too much effort for this.