### PR TITLE
Remove Swashbuckle

### DIFF
--- a/source/Server/IntegratedAuthentication/IntegratedAuthenticationController.cs
+++ b/source/Server/IntegratedAuthentication/IntegratedAuthenticationController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Octopus.Server.Extensibility.Authentication.DirectoryServices.Configuration;
 using Octopus.Server.Extensibility.Web.Extensions;
-using Swashbuckle.AspNetCore.Annotations;
 
 namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.IntegratedAuthentication
 {
@@ -25,10 +24,6 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Integrat
 
         [AllowAnonymous]
         [HttpGet("integrated-challenge")]
-        [SwaggerOperation(
-            Summary = "Challenge the request against the integrated authentication scheme",
-            OperationId = "getIntegratedChallenge"
-        )]
         public async Task IntegratedChallenge()
         {
             if (!directoryServicesConfigurationStore.GetIsEnabled())

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="Octopus.Server.Extensibility.Web" Version="0.0.24" />
     <PackageReference Include="Octopus.Time" Version="1.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.2.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.6.3" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Web\Static\images\directory_services_signin_buttons\microsoft-logo.svg" />


### PR DESCRIPTION
Since operation ids are no longer required (https://github.com/OctopusDeploy/OctopusDeploy/pull/11783) we can remove exposing any unnecessary internal API infrastructure from this auth provider.

Relates to https://github.com/OctopusDeploy/ResearchAndDevelopment/issues/370