### PR TITLE
Fix for domain fallback for samAccountNames

### DIFF
--- a/source/DirectoryServices.Tests/DirectoryServicesExternalSecurityGroupLocatorTests.cs
+++ b/source/DirectoryServices.Tests/DirectoryServicesExternalSecurityGroupLocatorTests.cs
@@ -49,7 +49,7 @@ namespace DirectoryServices.Tests
         [Test]
         public void GetGroupIdsForUser_NotFound()
         {
-            userPrincipalFinder.FindByIdentity(null, null).ReturnsForAnyArgs((IUserPrincipalWrapper) null);
+            userPrincipalFinder.FindByIdentity(Arg.Any<PrincipalContext>(), Arg.Any<string>()).Returns((IUserPrincipalWrapper) null);
 
             var result = locator.GetGroupIdsForUser("Bob", CancellationToken.None);
             result.WasAbleToRetrieveGroups.ShouldBeFalse();
@@ -62,7 +62,7 @@ namespace DirectoryServices.Tests
         {
 
             var userPrincipal = Substitute.For<IUserPrincipalWrapper>();
-            userPrincipalFinder.FindByIdentity(null, null).ReturnsForAnyArgs(userPrincipal);
+            userPrincipalFinder.FindByIdentity(Arg.Any<PrincipalContext>(), Arg.Any<string>()).Returns(userPrincipal);
 
             var authGroupsException = new Exception("AuthorizationGroups Exception");
             userPrincipal.GetAuthorizationGroups(CancellationToken.None).ThrowsForAnyArgs(authGroupsException);
@@ -83,7 +83,7 @@ namespace DirectoryServices.Tests
         public void GetGroupIdsForUser_ErrorGettingAnyGroups()
         {
             var userPrincipal = Substitute.For<IUserPrincipalWrapper>();
-            userPrincipalFinder.FindByIdentity(null, null).ReturnsForAnyArgs(userPrincipal);
+            userPrincipalFinder.FindByIdentity(Arg.Any<PrincipalContext>(), Arg.Any<string>()).Returns(userPrincipal);
 
             var authGroupsException = new Exception("AuthorizationGroups Exception");
             userPrincipal.GetAuthorizationGroups(CancellationToken.None).ThrowsForAnyArgs(authGroupsException);
@@ -105,7 +105,7 @@ namespace DirectoryServices.Tests
         {
 
             var userPrincipal = Substitute.For<IUserPrincipalWrapper>();
-            userPrincipalFinder.FindByIdentity(null, null).ReturnsForAnyArgs(userPrincipal);
+            userPrincipalFinder.FindByIdentity(Arg.Any<PrincipalContext>(), Arg.Any<string>()).Returns(userPrincipal);
 
             userPrincipal.GetAuthorizationGroups(CancellationToken.None).ReturnsForAnyArgs(new[] {new FakeGroupPrincipal(groupSid)});
 

--- a/source/Server/DirectoryServices/DirectoryServicesCredentialValidator.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesCredentialValidator.cs
@@ -61,7 +61,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
                 return ResultFromExtension<IUser>.Failed(validatedUser.ValidationMessage);
             }
 
-            return GetOrCreateUser(validatedUser, validatedUser.UserPrincipalName, validatedUser.Domain, cancellationToken);
+            return GetOrCreateUser(validatedUser, validatedUser.UserPrincipalName, validatedUser.Domain ?? EnvironmentUserDomainName, cancellationToken);
         }
 
         public IResultFromExtension<IUser> GetOrCreateUser(string username, CancellationToken cancellationToken)
@@ -81,9 +81,9 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
             var userPrincipalName = objectNameNormalizer.ValidatedUserPrincipalName(principal.UserPrincipalName, fallbackUsername, fallbackDomain);
 
             var samAccountName = principal.SamAccountName ?? string.Empty;
-            if (!string.IsNullOrWhiteSpace(fallbackDomain) && !samAccountName.Contains("\\"))
+            if (!string.IsNullOrWhiteSpace(fallbackDomain) && (!samAccountName.Contains("\\") || samAccountName.StartsWith("\\")))
             {
-                samAccountName = fallbackDomain + @"\" + samAccountName;
+                samAccountName = fallbackDomain + @"\" + samAccountName.TrimStart('\\');
             }
 
             var displayName = principal.DisplayName ?? string.Empty;

--- a/source/Server/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
+++ b/source/Server/DirectoryServices/DirectoryServicesExternalSecurityGroupLocator.cs
@@ -130,7 +130,8 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 
                     // Reads just the groups they are a member of - more reliable but not ideal
                     using (var principal = userPrincipalFinder.FindByIdentity(context, samAccountName))
-                        ReadUserGroups(principal, groups, cancellationToken);
+                        if (principal is not null)
+                            ReadUserGroups(principal, groups, cancellationToken);
 
                     return new DirectoryServicesExternalSecurityGroupLocatorResult(groups);
                 }

--- a/source/Server/DirectoryServices/UserPrincipalFinder.cs
+++ b/source/Server/DirectoryServices/UserPrincipalFinder.cs
@@ -4,12 +4,15 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
 {
     interface IUserPrincipalFinder
     {
-        IUserPrincipalWrapper FindByIdentity(PrincipalContext context, string samAccountName);
+        IUserPrincipalWrapper? FindByIdentity(PrincipalContext context, string samAccountName);
     }
 
     class UserPrincipalFinder : IUserPrincipalFinder
     {
-        public IUserPrincipalWrapper FindByIdentity(PrincipalContext context, string samAccountName)
-            => new UserPrincipalWrapper(UserPrincipal.FindByIdentity(context, samAccountName));
+        public IUserPrincipalWrapper? FindByIdentity(PrincipalContext context, string samAccountName)
+        {
+            var findByIdentity = UserPrincipal.FindByIdentity(context, samAccountName);
+            return findByIdentity is null ? null : new UserPrincipalWrapper(findByIdentity);
+        }
     }
 }

--- a/source/Server/DirectoryServices/UserValidationResult.cs
+++ b/source/Server/DirectoryServices/UserValidationResult.cs
@@ -7,7 +7,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         public UserValidationResult(UserPrincipal userPrincipal, string? domain)
             :this(userPrincipal.UserPrincipalName,
                 $"{domain}\\{userPrincipal.SamAccountName}",
-                domain, 
+                domain,
                 string.IsNullOrWhiteSpace(userPrincipal.DisplayName) ? userPrincipal.Name : userPrincipal.DisplayName,
                 userPrincipal.EmailAddress)
         {
@@ -16,7 +16,7 @@ namespace Octopus.Server.Extensibility.Authentication.DirectoryServices.Director
         public UserValidationResult(string userPrincipalName, string samAccountName, string? domain, string displayName, string emailAddress)
         {
             UserPrincipalName = userPrincipalName;
-            SamAccountName = samAccountName.Contains("\\") ? samAccountName : $"{domain}\\{samAccountName}";
+            SamAccountName = samAccountName.Contains("\\") && !samAccountName.StartsWith("\\") ? samAccountName : $"{domain}\\{samAccountName.TrimStart('\\')}";
             Domain = domain;
             DisplayName = displayName;
             EmailAddress = emailAddress;


### PR DESCRIPTION
Refactoring of the credential validator code a while back, in conjunction with changes in NetCore vs NetFramework, regressed the way domain names were handled for samAccountName.

Previously the samAccountNames would either not include a domain or would correctly include the domain of the Octopus service account user (if the located user was in the same domain). This is changed to where it can now be returned as `\someusername`.

This PR updates the handling code to put the correct default domain prefix in when this scenario occurs.

It also fixes a null reference exception that was occurring during group lookup, if a user Octopus knows about has been removed from the Active Directory.